### PR TITLE
win64 compatibility for busybox-w32

### DIFF
--- a/include/mingw.h
+++ b/include/mingw.h
@@ -8,7 +8,11 @@
  */
 typedef int gid_t;
 typedef int uid_t;
+#ifdef _WIN64
+typedef __int64 pid_t;
+#else
 typedef int pid_t;
+#endif
 
 /*
  * arpa/inet.h
@@ -240,7 +244,7 @@ int mingw_mkdir(const char *path, int mode);
 # define off_t off64_t
 #endif
 #define lseek _lseeki64
-#define stat _stati64
+#define stat _stat64
 int mingw_lstat(const char *file_name, struct stat *buf);
 int mingw_stat(const char *file_name, struct stat *buf);
 int mingw_fstat(int fd, struct stat *buf);


### PR DESCRIPTION
Allows busybox-w32 to be built with the **x86_64-w64-mingw32** cross compiler for a win64 target.

Previously, compilation was possible on **i686-w64-mingw32** where `pid_t` was of type `int`.  However, on win64, `pid_t` is of type `__int64`, conflicting with the definition in **include/mingw.h**.

Also, `struct stat` structures were defined on win32 using `#define stat _stati64` in **/usr/x86_64-w64-mingw32/include/_mingw_stat64.h** (and also **/usr/i686-w64-mingw32/include/_mingw_stat64.h**).  The line `#define _stati64 _stat64` is not called during win64 compilation, so it's done manually here.