### PR TITLE
Fix error: conflicting types for ‘pid_t’ with mingw64

### DIFF
--- a/include/mingw.h
+++ b/include/mingw.h
@@ -7,7 +7,11 @@
  */
 typedef int gid_t;
 typedef int uid_t;
+#ifndef _WIN64
 typedef int pid_t;
+#else
+typedef __int64 pid_t;
+#endif
 
 /*
  * arpa/inet.h


### PR DESCRIPTION
Using x86_64-w64-mingw32-gcc cross-compiler for win64 gives an error:

```
In file included from include/libbb.h:163:0,
                 from include/busybox.h:8,
                 from applets/applets.c:9:
include/mingw.h:10:13: error: conflicting types for ‘pid_t’
 typedef int pid_t;
             ^
In file included from /usr/share/mingw-w64/include/process.h:12:0,
                 from /usr/share/mingw-w64/include/unistd.h:11,
                 from include/platform.h:313,
                 from include/libbb.h:13,
                 from include/busybox.h:8,
                 from applets/applets.c:9:
/usr/share/mingw-w64/include/sys/types.h:68:16: note: previous declaration of ‘pid_t’ was here
 typedef _pid_t pid_t;
                ^
make[1]: *** [applets/applets.o] Error 1
```

This change fixes it and results in a successful build of 64-bit busybox.exe.

I do still need to test these binaries out, but looks encouraging. Thanks so much for getting MinGW-w64 support working, the changes were smaller than I thought they might be!

Would it be too much trouble to ask you to tag a recent version? I'd like to submit this to openSUSE's cross-compiled packages collection here https://build.opensuse.org/project/show/windows:mingw:win64, setting a git sha as my version number gives an rpmlint warning about the filename being too long :)