### PR TITLE
Use %I64* formats with MinGW instead of %ll* formats

### DIFF
--- a/coreutils/expr.c
+++ b/coreutils/expr.c
@@ -84,7 +84,7 @@
 #if ENABLE_EXPR_MATH_SUPPORT_64
 typedef int64_t arith_t;
 
-#define PF_REZ      "ll"
+#define PF_REZ      LL_FMT
 #define PF_REZ_TYPE (long long)
 #define STRTOL(s, e, b) strtoll(s, e, b)
 #else

--- a/coreutils/factor.c
+++ b/coreutils/factor.c
@@ -161,7 +161,7 @@ static NOINLINE void factorize(wide_t N)
 	}
  end:
 	if (N > 1)
-		printf(" %llu", N);
+		printf(" %"LL_FMT"u", N);
 	bb_putchar('\n');
 }
 
@@ -175,7 +175,7 @@ static void factorize_numstr(const char *numstr)
 	N = bb_strtoull(numstr, NULL, 10);
 	if (errno)
 		bb_show_usage();
-	printf("%llu:", N);
+	printf("%"LL_FMT"u:", N);
 	factorize(N);
 }
 

--- a/coreutils/ls.c
+++ b/coreutils/ls.c
@@ -496,7 +496,7 @@ static NOINLINE unsigned display_single(const struct dnode *dn)
 			lpath = xmalloc_readlink_or_warn(dn->fullname);
 
 	if (opt & OPT_i) /* show inode# */
-		column += printf("%7llu ", (long long) dn->dn_ino);
+		column += printf("%7"LL_FMT"u ", (long long) dn->dn_ino);
 //TODO: -h should affect -s too:
 	if (opt & OPT_s) /* show allocated blocks */
 		column += printf("%6"OFF_FMT"u ", (off_t) (dn->dn_blocks >> 1));

--- a/coreutils/sum.c
+++ b/coreutils/sum.c
@@ -82,9 +82,9 @@ static unsigned sum_file(const char *file, unsigned type)
 	if (type >= SUM_SYSV) {
 		r = (s & 0xffff) + ((s & 0xffffffff) >> 16);
 		s = (r & 0xffff) + (r >> 16);
-		printf("%u %llu %s\n", s, (total_bytes + 511) / 512, file);
+		printf("%u %"LL_FMT"u %s\n", s, (total_bytes + 511) / 512, file);
 	} else
-		printf("%05u %5llu %s\n", s, (total_bytes + 1023) / 1024, file);
+		printf("%05u %5"OFF_FMT"u %s\n", s, (total_bytes + 1023) / 1024, file);
 	return 1;
 #undef buf
 }

--- a/editors/awk.c
+++ b/editors/awk.c
@@ -2078,7 +2078,7 @@ static int fmt_num(char *b, int size, const char *format, double n, int int_as_i
 	const char *s = format;
 
 	if (int_as_int && n == (long long)n) {
-		r = snprintf(b, size, "%lld", (long long)n);
+		r = snprintf(b, size, "%"LL_FMT"d", (long long)n);
 	} else {
 		do { c = *s; } while (c && *++s);
 		if (strchr("diouxX", c)) {

--- a/include/libbb.h
+++ b/include/libbb.h
@@ -252,6 +252,13 @@ PUSH_AND_SET_FUNCTION_VISIBILITY_TO_HIDDEN
 	: ((T)1 << (sizeof(T)*8-1)) \
 	)
 
+#if ENABLE_PLATFORM_MINGW32 && \
+	(!defined(__USE_MINGW_ANSI_STDIO) || !__USE_MINGW_ANSI_STDIO)
+#define LL_FMT "I64"
+#else
+#define LL_FMT "ll"
+#endif
+
 /* Large file support */
 /* Note that CONFIG_LFS=y forces bbox to be built with all common ops
  * (stat, lseek etc) mapped to "largefile" variants by libc.
@@ -277,7 +284,7 @@ typedef unsigned long long uoff_t;
 #  define XATOOFF(a) xatoull_range((a), 0, LLONG_MAX)
 #  define BB_STRTOOFF bb_strtoull
 #  define STRTOOFF strtoull
-#  define OFF_FMT "ll"
+#  define OFF_FMT LL_FMT
 # endif
 #else
 /* CONFIG_LFS is off */

--- a/libbb/xatonum_template.c
+++ b/libbb/xatonum_template.c
@@ -67,7 +67,7 @@ unsigned type FAST_FUNC xstrtou(_range_sfx)(const char *numstr, int base,
 	if (r >= lower && r <= upper)
 		return r;
  range:
-	bb_error_msg_and_die("number %s is not in %llu..%llu range",
+	bb_error_msg_and_die("number %s is not in %"LL_FMT"u..%"LL_FMT"u range",
 		numstr, (unsigned long long)lower,
 		(unsigned long long)upper);
  inval:
@@ -144,7 +144,8 @@ type FAST_FUNC xstrto(_range_sfx)(const char *numstr, int base,
 	}
 
 	if (r < lower || r > upper) {
-		bb_error_msg_and_die("number %s is not in %lld..%lld range",
+		bb_error_msg_and_die("number %s is not in "
+				"%"LL_FMT"d..%"LL_FMT"d range",
 				numstr, (long long)lower, (long long)upper);
 	}
 

--- a/miscutils/dc.c
+++ b/miscutils/dc.c
@@ -56,7 +56,7 @@ typedef unsigned long data_t;
 #define DATA_FMT "l"
 #else
 typedef unsigned long long data_t;
-#define DATA_FMT "ll"
+#define DATA_FMT LL_FMT
 #endif
 
 

--- a/procps/iostat.c
+++ b/procps/iostat.c
@@ -29,7 +29,7 @@
 #if 1
 typedef unsigned long long cputime_t;
 typedef long long icputime_t;
-# define FMT_DATA "ll"
+# define FMT_DATA LL_FMT
 # define CPUTIME_MAX (~0ULL)
 #else
 typedef unsigned long cputime_t;

--- a/procps/mpstat.c
+++ b/procps/mpstat.c
@@ -49,7 +49,7 @@
 #if 1
 typedef unsigned long long data_t;
 typedef long long idata_t;
-#define FMT_DATA "ll"
+#define FMT_DATA LL_FMT
 #define DATA_MAX ULLONG_MAX
 #else
 typedef unsigned long data_t;

--- a/shell/math.h
+++ b/shell/math.h
@@ -65,7 +65,7 @@ PUSH_AND_SET_FUNCTION_VISIBILITY_TO_HIDDEN
 
 #if ENABLE_FEATURE_SH_MATH_64
 typedef long long arith_t;
-#define ARITH_FMT "%lld"
+#define ARITH_FMT "%"LL_FMT"d"
 #define strto_arith_t strtoull
 #else
 typedef long arith_t;


### PR DESCRIPTION
The MSVC runtime uses the format specified %I64 for 64-bit data types;
It does not understand e.g. %llu for unsigned long longs.

However, mingw-w64 provides a compatibility mode in its runtime wrapper
which can be activated by defining the constant __USE_MINGW_ANSI_STDIO=1
in which case we must refrain from overriding the %ll* formats.

This fixes quite a couple of compile warnings when building with the
mingw-w64 compiler.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>