### PR TITLE
Fix some compiler warnings

### DIFF
--- a/findutils/xargs.c
+++ b/findutils/xargs.c
@@ -405,7 +405,9 @@ static char* FAST_FUNC process_stdin_with_replace(int n_max_chars, int n_max_arg
  */
 static int xargs_ask_confirmation(void)
 {
+#if !ENABLE_PLATFORM_MINGW32
 	FILE *tty_stream;
+#endif
 	int c, savec;
 
 #if !ENABLE_PLATFORM_MINGW32

--- a/include/mingw.h
+++ b/include/mingw.h
@@ -452,7 +452,9 @@ DIR *mingw_opendir(const char *path);
  * MinGW specific
  */
 #define is_dir_sep(c) ((c) == '/' || (c) == '\\')
+#ifndef PRIuMAX
 #define PRIuMAX "I64u"
+#endif
 
 pid_t FAST_FUNC mingw_spawn(char **argv);
 intptr_t FAST_FUNC mingw_spawn_proc(const char **argv);

--- a/include/mingw.h
+++ b/include/mingw.h
@@ -455,10 +455,10 @@ DIR *mingw_opendir(const char *path);
 #define PRIuMAX "I64u"
 
 pid_t FAST_FUNC mingw_spawn(char **argv);
-intptr_t FAST_FUNC mingw_spawn_proc(char **argv);
-int mingw_execv(const char *cmd, const char *const *argv);
-int mingw_execvp(const char *cmd, const char *const *argv);
-int mingw_execve(const char *cmd, const char *const *argv, const char *const *envp);
+intptr_t FAST_FUNC mingw_spawn_proc(const char **argv);
+int mingw_execv(const char *cmd, char *const *argv);
+int mingw_execvp(const char *cmd, char *const *argv);
+int mingw_execve(const char *cmd, char *const *argv, char *const *envp);
 #define spawn mingw_spawn
 #define execvp mingw_execvp
 #define execve mingw_execve
@@ -472,7 +472,7 @@ const char * next_path_sep(const char *path);
  * helpers
  */
 
-char **copy_environ(const char *const *env);
+char **copy_environ(char *const *env);
 void free_environ(char **env);
 char **env_setenv(char **env, const char *name);
 

--- a/libbb/find_mount_point.c
+++ b/libbb/find_mount_point.c
@@ -35,8 +35,13 @@ struct mntent* FAST_FUNC find_mount_point(const char *name,
 #else
 	static char mnt_fsname[4];
 	static char mnt_dir[4];
-	static struct mntent my_mount_entry = { mnt_fsname, mnt_dir, "", "", 0, 0 };
-	char *current, *path;
+	static char mnt_type[1];
+	static char mnt_opts[1];
+	static struct mntent my_mount_entry = {
+		mnt_fsname, mnt_dir, mnt_type, mnt_opts, 0, 0
+	};
+	char *current;
+	const char *path;
 	DWORD len;
 #endif
 

--- a/libbb/find_mount_point.c
+++ b/libbb/find_mount_point.c
@@ -20,11 +20,12 @@
 struct mntent* FAST_FUNC find_mount_point(const char *name, int subdir_too)
 {
 	struct stat s;
-	FILE *mtab_fp;
 	struct mntent *mountEntry;
+#if !ENABLE_PLATFORM_MINGW32
+	FILE *mtab_fp;
 	dev_t devno_of_name;
 	bool block_dev;
-#if ENABLE_PLATFORM_MINGW32
+#else
 	static char mnt_fsname[4];
 	static char mnt_dir[4];
 	static struct mntent my_mount_entry = { mnt_fsname, mnt_dir, "", "", 0, 0 };

--- a/libbb/find_mount_point.c
+++ b/libbb/find_mount_point.c
@@ -10,6 +10,12 @@
 #include "libbb.h"
 #include <mntent.h>
 
+#ifdef __MINGW32__
+#define MINGW32_UNUSED_PARAM UNUSED_PARAM
+#else
+#define MINGW32_UNUSED_PARAM
+#endif
+
 /*
  * Given a block device, find the mount table entry if that block device
  * is mounted.
@@ -17,7 +23,8 @@
  * Given any other file (or directory), find the mount table entry for its
  * filesystem.
  */
-struct mntent* FAST_FUNC find_mount_point(const char *name, int subdir_too)
+struct mntent* FAST_FUNC find_mount_point(const char *name,
+		int MINGW32_UNUSED_PARAM subdir_too)
 {
 	struct stat s;
 	struct mntent *mountEntry;

--- a/libbb/find_pid_by_name.c
+++ b/libbb/find_pid_by_name.c
@@ -40,8 +40,10 @@ and therefore comm field contains "exe".
 
 static int comm_match(procps_status_t *p, const char *procName)
 {
+#if !ENABLE_PLATFORM_MINGW32
 	int argv1idx;
 	const char *argv1;
+#endif
 
 	if (strncmp(p->comm, procName, 15) != 0)
 		return 0; /* comm does not match */

--- a/libbb/inode_hash.c
+++ b/libbb/inode_hash.c
@@ -56,8 +56,14 @@ char* FAST_FUNC is_in_ino_dev_hashtable(const struct stat *statbuf)
 	return NULL;
 }
 
+#if ENABLE_PLATFORM_MINGW32
+#define MINGW32_UNUSED_PARAM UNUSED_PARAM
+#else
+#define MINGW32_UNUSED_PARAM
+#endif
+
 /* Add statbuf to statbuf hash table */
-void FAST_FUNC add_to_ino_dev_hashtable(const struct stat *statbuf, const char *name)
+void FAST_FUNC add_to_ino_dev_hashtable(MINGW32_UNUSED_PARAM const struct stat *statbuf, MINGW32_UNUSED_PARAM const char *name)
 {
 #if !ENABLE_PLATFORM_MINGW32
 	int i;

--- a/miscutils/less.c
+++ b/miscutils/less.c
@@ -1820,10 +1820,12 @@ static void keypress_process(int keypress)
 		number_process(keypress);
 }
 
+#if !ENABLE_PLATFORM_MINGW32
 static void sig_catcher(int sig)
 {
 	less_exit(- sig);
 }
+#endif
 
 #if ENABLE_FEATURE_LESS_WINCH
 static void sigwinch_handler(int sig UNUSED_PARAM)

--- a/miscutils/man.c
+++ b/miscutils/man.c
@@ -201,7 +201,7 @@ static char **add_MANPATH(char **man_path_list, int *count_mp, char *path)
 		char **path_element;
 
 #if ENABLE_PLATFORM_MINGW32
-		next_path = next_path_sep(path);
+		next_path = (char *)next_path_sep(path);
 #else
 		next_path = strchr(path, ':');
 #endif

--- a/win32/env.c
+++ b/win32/env.c
@@ -1,6 +1,6 @@
 #include "libbb.h"
 
-char **copy_environ(const char *const *envp)
+char **copy_environ(char *const *envp)
 {
 	char **env;
 	int i = 0;

--- a/win32/fnmatch.c
+++ b/win32/fnmatch.c
@@ -120,7 +120,7 @@
    whose names are inconsistent.  */
 
 # if !defined _LIBC && !defined getenv
-extern char *getenv ();
+extern char *getenv (const char *);
 # endif
 
 # ifndef errno

--- a/win32/fnmatch.c
+++ b/win32/fnmatch.c
@@ -131,9 +131,7 @@ extern int errno;
 
 # if !defined HAVE___STRCHRNUL && !defined _LIBC
 static char *
-__strchrnul (s, c)
-     const char *s;
-     int c;
+__strchrnul (const char *s, int c)
 {
   char *result = strchr (s, c);
   if (result == NULL)
@@ -155,11 +153,8 @@ static int internal_fnmatch __P ((const char *pattern, const char *string,
      internal_function;
 static int
 internal_function
-internal_fnmatch (pattern, string, no_leading_period, flags)
-     const char *pattern;
-     const char *string;
-     int no_leading_period;
-     int flags;
+internal_fnmatch (const char *pattern, const char *string,
+                  int no_leading_period, int flags)
 {
   register const char *p = pattern, *n = string;
   register unsigned char c;
@@ -477,10 +472,7 @@ internal_fnmatch (pattern, string, no_leading_period, flags)
 
 
 int
-fnmatch (pattern, string, flags)
-     const char *pattern;
-     const char *string;
-     int flags;
+fnmatch (const char *pattern, const char *string, int flags)
 {
   return internal_fnmatch (pattern, string, flags & FNM_PERIOD, flags);
 }

--- a/win32/process.c
+++ b/win32/process.c
@@ -208,14 +208,14 @@ quote_arg(const char *arg)
 }
 
 static intptr_t
-spawnveq(int mode, const char *path, const char *const *argv, const char *const *env)
+spawnveq(int mode, const char *path, char *const *argv, char *const *env)
 {
 	char **new_argv;
 	int i, argc = 0;
 	intptr_t ret;
 
 	if (!argv) {
-		const char *empty_argv[] = { path, NULL };
+		char *const empty_argv[] = { (char *)path, NULL };
 		return spawnve(mode, path, empty_argv, env);
 	}
 
@@ -227,7 +227,7 @@ spawnveq(int mode, const char *path, const char *const *argv, const char *const 
 	for (i = 0;i < argc;i++)
 		new_argv[i] = quote_arg(argv[i]);
 	new_argv[argc] = NULL;
-	ret = spawnve(mode, path, (const char *const *)new_argv, env);
+	ret = spawnve(mode, path, new_argv, env);
 	for (i = 0;i < argc;i++)
 		if (new_argv[i] != argv[i])
 			free(new_argv[i]);
@@ -238,21 +238,21 @@ spawnveq(int mode, const char *path, const char *const *argv, const char *const 
 #if ENABLE_FEATURE_PREFER_APPLETS || ENABLE_FEATURE_SH_STANDALONE
 static intptr_t
 mingw_spawn_applet(int mode,
-		   const char *const *argv,
-		   const char *const *envp)
+		   char *const *argv,
+		   char *const *envp)
 {
 	return spawnveq(mode, bb_busybox_exec_path, argv, envp);
 }
 #endif
 
 static intptr_t
-mingw_spawn_interpreter(int mode, const char *prog, const char *const *argv, const char *const *envp)
+mingw_spawn_interpreter(int mode, const char *prog, char *const *argv, char *const *envp)
 {
 	intptr_t ret;
 	char **opts;
 	int nopts;
 	const char *interpr = parse_interpreter(prog, &opts, &nopts);
-	const char **new_argv;
+	char **new_argv;
 	int argc = 0;
 
 	if (!interpr)
@@ -264,11 +264,11 @@ mingw_spawn_interpreter(int mode, const char *prog, const char *const *argv, con
 	new_argv = malloc(sizeof(*argv)*(argc+nopts+2));
 	memcpy(new_argv+1, opts, sizeof(*opts)*nopts);
 	memcpy(new_argv+nopts+2, argv+1, sizeof(*argv)*argc);
-	new_argv[nopts+1] = prog; /* pass absolute path */
+	new_argv[nopts+1] = (char *)prog; /* pass absolute path */
 
 #if ENABLE_FEATURE_PREFER_APPLETS || ENABLE_FEATURE_SH_STANDALONE
 	if (find_applet_by_name(interpr) >= 0) {
-		new_argv[0] = interpr;
+		new_argv[0] = (char *)interpr;
 		ret = mingw_spawn_applet(mode, new_argv, envp);
 	} else
 #endif
@@ -292,7 +292,7 @@ mingw_spawn_interpreter(int mode, const char *prog, const char *const *argv, con
 }
 
 static intptr_t
-mingw_spawn_1(int mode, const char *cmd, const char *const *argv, const char *const *envp)
+mingw_spawn_1(int mode, const char *cmd, char *const *argv, char *const *envp)
 {
 	intptr_t ret;
 
@@ -331,30 +331,28 @@ mingw_spawn(char **argv)
 {
 	intptr_t ret;
 
-	ret = mingw_spawn_1(P_NOWAIT, argv[0], (const char *const *)argv,
-			(const char *const *)environ);
+	ret = mingw_spawn_1(P_NOWAIT, argv[0], (char *const *)argv, environ);
 
 	return ret == -1 ? -1 : GetProcessId((HANDLE)ret);
 }
 
 intptr_t FAST_FUNC
-mingw_spawn_proc(char **argv)
+mingw_spawn_proc(const char **argv)
 {
-	return mingw_spawn_1(P_NOWAIT, argv[0], (const char *const *)argv,
-			(const char *const *)environ);
+	return mingw_spawn_1(P_NOWAIT, argv[0], (char *const *)argv, environ);
 }
 
 int
-mingw_execvp(const char *cmd, const char *const *argv)
+mingw_execvp(const char *cmd, char *const *argv)
 {
-	int ret = (int)mingw_spawn_1(P_WAIT, cmd, argv, (const char *const *)environ);
+	int ret = (int)mingw_spawn_1(P_WAIT, cmd, argv, environ);
 	if (ret != -1)
 		exit(ret);
 	return ret;
 }
 
 int
-mingw_execve(const char *cmd, const char *const *argv, const char *const *envp)
+mingw_execve(const char *cmd, char *const *argv, char *const *envp)
 {
 	int ret;
 	int mode = P_WAIT;
@@ -366,9 +364,9 @@ mingw_execve(const char *cmd, const char *const *argv, const char *const *envp)
 }
 
 int
-mingw_execv(const char *cmd, const char *const *argv)
+mingw_execv(const char *cmd, char *const *argv)
 {
-	return mingw_execve(cmd, argv, (const char *const *)environ);
+	return mingw_execve(cmd, argv, environ);
 }
 
 /* POSIX version in libbb/procps.c */

--- a/win32/select.c
+++ b/win32/select.c
@@ -252,7 +252,7 @@ mingw_select (int nfds, fd_set *rfds, fd_set *wfds, fd_set *xfds,
   DWORD ret, wait_timeout, nhandles, nsock, nbuffer;
   MSG msg;
   int i, fd, rc;
-  clock_t tend;
+  clock_t tend = 0;
 
   if (nfds > FD_SETSIZE)
     nfds = FD_SETSIZE;

--- a/win32/select.c
+++ b/win32/select.c
@@ -18,6 +18,7 @@
    You should have received a copy of the GNU General Public License along
    with this program; if not, see <http://www.gnu.org/licenses/>.  */
 
+#include "libbb.h"
 #include <malloc.h>
 #include <assert.h>
 

--- a/win32/strptime.c
+++ b/win32/strptime.c
@@ -21,6 +21,7 @@
  * and lightly edited.
  */
 
+#include "libbb.h"
 #include <time.h>
 
 #include <assert.h>

--- a/win32/strptime.c
+++ b/win32/strptime.c
@@ -62,7 +62,7 @@ enum ptime_locale_status { not, loc, raw };
 #define recursive(new_fmt) \
   (*(new_fmt) != '\0'                                                         \
    && (rp = __strptime_internal (rp, (new_fmt), tm,                           \
-                                 decided, era_cnt LOCALE_ARG)) != NULL)
+                                 decided, era_cnt)) != NULL)
 
 
 static char const weekday_name[][10] =
@@ -99,11 +99,6 @@ static const unsigned short int __mon_yday[2][13] =
     { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 }
   };
 
-# define LOCALE_PARAM
-# define LOCALE_ARG
-# define LOCALE_PARAM_DECL
-# define LOCALE_PARAM_PROTO
-# define HELPER_LOCALE_ARG
 # define ISSPACE(Ch) isspace (Ch)
 
 
@@ -144,13 +139,8 @@ day_of_the_year (struct tm *tm)
 
 
 static char *
-__strptime_internal (rp, fmt, tm, decided, era_cnt LOCALE_PARAM)
-     const char *rp;
-     const char *fmt;
-     struct tm *tm;
-     enum ptime_locale_status *decided;
-     int era_cnt;
-     LOCALE_PARAM_DECL
+__strptime_internal (const char *rp, const char *fmt, struct tm *tm,
+                     enum ptime_locale_status *decided, int era_cnt)
 {
 
   int cnt;
@@ -633,15 +623,11 @@ __strptime_internal (rp, fmt, tm, decided, era_cnt LOCALE_PARAM)
 
 
 char *
-strptime (buf, format, tm LOCALE_PARAM)
-     const char *buf;
-     const char *format;
-     struct tm *tm;
-     LOCALE_PARAM_DECL
+strptime (const char *buf, const char *format, struct tm *tm)
 {
   enum ptime_locale_status decided;
 
   decided = raw;
-  return __strptime_internal (buf, format, tm, &decided, -1 LOCALE_ARG);
+  return __strptime_internal (buf, format, tm, &decided, -1);
 }
 

--- a/win32/system.c
+++ b/win32/system.c
@@ -10,7 +10,7 @@ int mingw_system(const char *cmd)
 	if (cmd == NULL)
 		return 1;
 
-	if ((proc=mingw_spawn_proc((char **)argv)) == -1)
+	if ((proc=mingw_spawn_proc(argv)) == -1)
 		return -1;
 
 	h = (HANDLE)proc;


### PR DESCRIPTION
In my experience, some of the compiler warnings point out legitimate concerns. Some of the warnings even turn into serious issues over the course of development, e.g. when casting a pointer to an `unsigned long` and back (which can easily fail on 64-bit Windows).

So here are the patches I came up with to squash the innocuous compiler warnings I encountered while trying to compile BusyBox-w32 so I could bundle it in a special version of [MinGit](https://github.com/git-for-windows/git/wiki/MinGit).

The patches themselves should be trivially correct. Less trivial patches still wait to be contributed after this Pull Request.