### PR TITLE
win32/strptime: fix for negative timezones

### DIFF
--- a/win32/strptime.c
+++ b/win32/strptime.c
@@ -456,6 +456,8 @@ __strptime_internal (rp, fmt, tm, decided, era_cnt LOCALE_PARAM)
               }
             if (val > 1200)
               return NULL;
+            if (neg)
+              val = -val;
           }
           break;
         case 'E':


### PR DESCRIPTION
I bet this has been fixed in gnulib, too.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>