### PR TITLE
bb_basename: handle mixed slashes correctly

### DIFF
--- a/libbb/get_last_path_component.c
+++ b/libbb/get_last_path_component.c
@@ -10,11 +10,13 @@
 
 const char* FAST_FUNC bb_basename(const char *name)
 {
-	const char *cp = strrchr(name, '/');
-	if (cp)
-		return cp + 1;
 #if ENABLE_PLATFORM_MINGW32
-	cp = strrchr(name, '\\');
+	const char *cp;
+	for (cp = name; *cp; cp++)
+		if (*cp == '/' || *cp == '\\')
+			name = cp + 1;
+#else
+	const char *cp = strrchr(name, '/');
 	if (cp)
 		return cp + 1;
 #endif


### PR DESCRIPTION
A path like C:/WINDOWS\system32 was handled incorrectly: it found the
forward slash, and then never bothered to look whether there was another
(back-)slash later on.

This fixes e.g. running BusyBox as C:/test\sh.exe

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>