### PR TITLE
xconnect: avoid using getsockname/getpeername on Windows

### DIFF
--- a/libbb/xconnect.c
+++ b/libbb/xconnect.c
@@ -69,6 +69,7 @@ int FAST_FUNC setsockopt_bindtodevice(int fd UNUSED_PARAM,
 }
 #endif
 
+#if !ENABLE_PLATFORM_MINGW32
 static len_and_sockaddr* get_lsa(int fd, int (*get_name)(int fd, struct sockaddr *addr, socklen_t *addrlen))
 {
 	len_and_sockaddr lsa;
@@ -97,6 +98,7 @@ len_and_sockaddr* FAST_FUNC get_peer_lsa(int fd)
 {
 	return get_lsa(fd, getpeername);
 }
+#endif
 
 void FAST_FUNC xconnect(int s, const struct sockaddr *saddr, socklen_t addrlen)
 {


### PR DESCRIPTION
The semantics of said functions is a bit different on Windows than on
Linux: it takes a `SOCKET` parameter instead of an `int` parameter, as
Windows does not use file descriptors for sockets.

The callers of these functions are only used in the daemons anyway,
though, and those are not compiled in busybox-w32.

Therefore, let's simply skip compiling those functions on Windows (as
well as `get_lsa()`, which would now be unused otherwise).

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>