### PR TITLE
mode_string: S_IFBLK differs between Windows and Unix

### DIFF
--- a/libbb/mode_string.c
+++ b/libbb/mode_string.c
@@ -25,7 +25,7 @@
 #endif
 
 #if ( S_IFSOCK!= 0140000 ) || ( S_IFLNK != 0120000 ) \
- || ( S_IFREG != 0100000 ) || ( S_IFBLK != 0060000 ) \
+ || ( S_IFREG != 0100000 ) || ( S_IFBLK != 0060000 && S_IFBLK != 0030000 ) \
  || ( S_IFDIR != 0040000 ) || ( S_IFCHR != 0020000 ) \
  || ( S_IFIFO != 0010000 )
 #warning mode type bitflag value assumption(s) violated! falling back to larger version


### PR DESCRIPTION
It is a bit wrong to make that much of a hard-coded assumption, anyway.

Maybe a better way would be to test whether the S_IF* constants are in a
specific range. But then, it is probably not worth the time to
investigate that.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>