### PR TITLE
libbb: exclude more Linux-specific functions from being compiled

### DIFF
--- a/libbb/vfork_daemon_rexec.c
+++ b/libbb/vfork_daemon_rexec.c
@@ -232,6 +232,7 @@ int FAST_FUNC spawn_and_wait(char **argv)
 	return wait4pid(rc);
 }
 
+#if !ENABLE_PLATFORM_MINGW32
 #if !BB_MMU
 void FAST_FUNC re_exec(char **argv)
 {
@@ -318,3 +319,4 @@ void FAST_FUNC bb_sanitize_stdio(void)
 {
 	bb_daemonize_or_rexec(DAEMON_ONLY_SANITIZE, NULL);
 }
+#endif /* !MINGW32 */


### PR DESCRIPTION
In 7a4491e1f (libbb: don't compile various Linux-specific functions,
2017-08-24), we started excluding a number of Linux-specific functions
that handle things like SELinux, ioctls, devices and forking.

But we forgot a couple functions that depend on the ones we now
excluded. This leads to compile failures with -Werror unless
cross-compiling on Linux, due to undefined symbols.

To fix this, exclude those functions which depend on the ones that were
excluded (they do not have any callers on Windows anyway, so all is
good).

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>