### PR TITLE
Several fixes to support 64-bit builds

### DIFF
--- a/coreutils/dd.c
+++ b/coreutils/dd.c
@@ -211,6 +211,12 @@ static bool write_and_stats(const void *buf, size_t len, size_t obs,
 # define XATOU_SFX xatoul_sfx
 #endif
 
+#if ENABLE_PLATFORM_MINGW32
+#define XATOSIZE_T xatoull_range_sfx
+#else
+#define XATOSIZE_T xatoul_range_sfx
+#endif
+
 #if ENABLE_FEATURE_DD_IBS_OBS
 static int parse_comma_flags(char *val, const char *words, const char *error_in)
 {
@@ -347,11 +353,11 @@ int dd_main(int argc UNUSED_PARAM, char **argv)
 #if ENABLE_FEATURE_DD_IBS_OBS
 		if (what == OP_ibs) {
 			/* Must fit into positive ssize_t */
-			ibs = xatoul_range_sfx(val, 1, ((size_t)-1L)/2, cwbkMG_suffixes);
+			ibs = XATOSIZE_T(val, 1, ((size_t)-1L)/2, cwbkMG_suffixes);
 			/*continue;*/
 		}
 		if (what == OP_obs) {
-			obs = xatoul_range_sfx(val, 1, ((size_t)-1L)/2, cwbkMG_suffixes);
+			obs = XATOSIZE_T(val, 1, ((size_t)-1L)/2, cwbkMG_suffixes);
 			/*continue;*/
 		}
 		if (what == OP_conv) {
@@ -364,7 +370,7 @@ int dd_main(int argc UNUSED_PARAM, char **argv)
 		}
 #endif
 		if (what == OP_bs) {
-			ibs = xatoul_range_sfx(val, 1, ((size_t)-1L)/2, cwbkMG_suffixes);
+			ibs = XATOSIZE_T(val, 1, ((size_t)-1L)/2, cwbkMG_suffixes);
 			obs = ibs;
 			/*continue;*/
 		}

--- a/shell/ash.c
+++ b/shell/ash.c
@@ -14716,7 +14716,7 @@ spawn_forkshell(struct job *jp, struct forkshell *fs, int mode)
 	intptr_t ret;
 
 	new = forkshell_prepare(fs);
-	sprintf(buf, "%x", (unsigned int)new->hMapFile);
+	sprintf(buf, "%p", new->hMapFile);
 	argv[2] = buf;
 	ret = mingw_spawn_proc(argv);
 	CloseHandle(new->hMapFile);

--- a/shell/ash.c
+++ b/shell/ash.c
@@ -15134,14 +15134,14 @@ static void
 forkshell_init(const char *idstr)
 {
 	struct forkshell *fs;
-	int map_handle;
+	void *map_handle;
 	HANDLE h;
 	struct globals_var **gvpp;
 	struct globals_misc **gmpp;
 	int i;
 	char **ptr;
 
-	if (sscanf(idstr, "%x", &map_handle) != 1)
+	if (sscanf(idstr, "%p", &map_handle) != 1)
 		bb_error_msg_and_die("invalid forkshell ID");
 
 	h = (HANDLE)map_handle;
@@ -15168,7 +15168,7 @@ forkshell_init(const char *idstr)
 		struct tblentry *e = fs->cmdtable[i];
 		while (e) {
 			if (e->cmdtype == CMDBUILTIN)
-				e->param.cmd = builtintab + (int)e->param.cmd;
+				e->param.cmd = builtintab + (int)(intptr_t)e->param.cmd;
 			e = e->next;
 		}
 	}

--- a/win32/poll.c
+++ b/win32/poll.c
@@ -72,7 +72,7 @@
 
 #ifdef WIN32_NATIVE
 
-#define IsConsoleHandle(h) (((long) (h) & 3) == 3)
+#define IsConsoleHandle(h) (((intptr_t) (h) & 3) == 3)
 
 static BOOL
 IsSocketHandle (HANDLE h)


### PR DESCRIPTION
The most obvious problem when porting 32-bit code to 64-bit is that one often encounters sloppy usage of data types: it may use `int` in place for more appropriate data types such as `size_t`, `off_t`, etc.

This is in particular a problem when code assumes that `long` simply must be big enough a data type to hold pointer values: this assumption is incorrect e.g. on 64-bit Windows, where `long` is 32-bit.

This set of patches fixes this class of problems in BusyBox-w32.