### PR TITLE
Uppercase only the PATH env variable

### DIFF
--- a/shell/ash.c
+++ b/shell/ash.c
@@ -14550,9 +14550,11 @@ init(void)
 				if (!(end=strchr(*envp, '=')))
 					continue;
 
-				/* make all variable names uppercase */
-				for (start = *envp;start < end;start++)
-					*start = toupper(*start);
+				/* make only the "Path" variable uppercase */
+				if (strncasecmp(*envp, "PATH=", 5) == 0) {
+					for (start = *envp;start < end;start++)
+						*start = toupper(*start);
+				}
 
 				/* skip conversion of variables known to cause problems */
 				if ( strncmp(*envp, "SYSTEMROOT=", 11) == 0 ||


### PR DESCRIPTION
busybox's env behaves differently, depending on how it is
called:

busybox.exe env  # env variable names casing is preserved.

or

busybox.exe sh -c "env"  # env variable names are uppercased.

But env on Linux preserves the casing, and so should busybox,
with the exception of the PATH variable, which must be uppercased,
otherwise the default value will be used instead, which can lead to
commands not being found.