### PR TITLE
Patch shebang trailing whitespace

### DIFF
--- a/testsuite/runtest
+++ b/testsuite/runtest
@@ -128,7 +128,11 @@ for i in $implemented; do
 	# Note: if $LINKSDIR/applet exists, we do not overwrite it.
 	# Useful if one wants to run tests against a standard utility,
 	# not an applet.
-	ln -s "$bindir/busybox" "$LINKSDIR/$i" 2>/dev/null
+	if [ -f $bindir/busybox.exe ]; then # Assume Windows if exe file exists
+		ln "$bindir/busybox.exe" "$LINKSDIR/$i.exe" 2>/dev/null
+	else
+		ln -s "$bindir/busybox" "$LINKSDIR/$i" 2>/dev/null
+	fi
 done
 
 # Set up option flags so tests can be selective.
@@ -146,7 +150,7 @@ for applet in $applets; do
 
 	# Is this a new-style test?
 	if [ -f "$applet.tests" ]; then
-		if [ ! -e "$LINKSDIR/$applet" ]; then
+		if [ ! -e "$LINKSDIR/$applet" ] && [ ! -e "$LINKSDIR/$applet.exe" ]; then
 			# (avoiding bash'ism "${applet:0:4}")
 			if ! echo "$applet" | grep "^all_" >/dev/null; then
 				echo "SKIPPED: $applet (not built)"

--- a/testsuite/sh.tests
+++ b/testsuite/sh.tests
@@ -1,0 +1,90 @@
+#!/bin/sh
+#
+# Test sh scripts
+#
+# Copyright 2019 by STMicroelectronics
+# Licensed under GPLv2, see file LICENSE in this source tree.
+
+. ./testing.sh
+
+test -f "$bindir/.config" && . "$bindir/.config"
+
+# testing "test name" "options" "expected result" "file input" "stdin"
+
+# Test case
+testing "test shebang" \
+	"uudecode; sh -c './shebang.sh'; echo \$?" \
+	"Hello world
+0
+" \
+"" "\
+begin-base64 755 shebang.sh
+IyEvYmluL3NoCmVjaG8gIkhlbGxvIHdvcmxkIgo=
+====
+"
+rm -f shebang.sh
+
+# Test case
+testing "test shebang with whitespace" \
+	"uudecode; sh -c './shebang_trailing_space.sh'; echo \$?" \
+	"Hello world
+0
+" \
+"" "\
+begin-base64 755 shebang_trailing_space.sh
+IyEvYmluL3NoIAplY2hvICJIZWxsbyB3b3JsZCIK
+====
+"
+rm -f shebang_trailing_space.sh
+
+# Test case
+testing "test shebang with argument" \
+	"uudecode; sh -c './shebang_argument.sh'; echo \$?" \
+	"Hello world
+0
+" \
+"" "\
+begin-base64 755 shebang_argument.sh
+IyEvYmluL3NoIC0KZWNobyAiSGVsbG8gd29ybGQiCg==
+====
+"
+rm -f shebang_argument.sh
+
+# Test case
+testing "test shebang with leading whitespace and argument" \
+       "uudecode; sh -c './shebang_leading_space_argument.sh'; echo \$?" \
+       "Hello world
+0
+" \
+"" "\
+begin-base64 755 shebang_leading_space_argument.sh
+IyEvYmluL3NoICAtCmVjaG8gIkhlbGxvIHdvcmxkIgo=
+====
+"
+rm -f shebang_leading_space_argument.sh
+
+# Test case
+testing "test shebang with argument and trailing whitespace" \
+	"uudecode; sh -c './shebang_argument_trailing_space.sh'; echo \$?" \
+	"Hello world
+0
+" \
+"" "\
+begin-base64 755 shebang_argument_trailing_space.sh
+IyEvYmluL3NoIC0gCmVjaG8gIkhlbGxvIHdvcmxkIgo=
+====
+"
+rm -f shebang_argument_trailing_space.sh
+
+# Test case
+testing "test shebang with leading whitepace, argument and trailing whitespace" \
+       "uudecode; sh -c './shebang_leading_argument_trailing_space.sh'; echo \$?" \
+       "Hello world
+0
+" \
+"" "\
+begin-base64 755 shebang_leading_argument_trailing_space.sh
+IyEvYmluL3NoICAtIAplY2hvICJIZWxsbyB3b3JsZCIK
+====
+"
+rm -f shebang_leading_argument_trailing_space.sh

--- a/win32/process.c
+++ b/win32/process.c
@@ -64,6 +64,10 @@ parse_interpreter(const char *cmd, interp_t *interp)
 		interp->path = path;
 		interp->name = t;
 		interp->opts = strtok(NULL, "\r\n");
+		/* Trim leading and trailing whitespace from the options.
+		 * If the resulting string is empty return a NULL pointer. */
+		if (interp->opts && trim(interp->opts) == interp->opts)
+			interp->opts = NULL;
 		return 1;
 	}
 


### PR DESCRIPTION
Busybox-w32 introduced a bug when it parses interpreter and options in scripts (shebang, #!), it treats trailing spaces as argument to the application. This patch restores old behavior where trailing spaces are removed.

Fixes problem with trailing whitespaces introduced in:
    97e2c4a05e8efa0e3e3a3c256daa05676dc5484e

Added tests for scripts with and without trailing spaces.

