### PR TITLE
Add a CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    if: github.repository == 'rmyorston/busybox-w32' || github.repository == 'dscho/busybox-w32'
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: git-for-windows/setup-git-for-windows-sdk@v0
+      with:
+        flavor: build-installers # this includes all the required tools
+    - name: restrict PATH to Git for Windows' SDK (and Windows)
+      shell: bash
+      run: echo 'PATH=/mingw64/bin:/usr/bin/:/c/Windows/system32' >>$GITHUB_ENV
+    - name: mingw64_defconfig
+      shell: bash
+      run: |
+        # We do not _actually_ cross-compile
+        sed -i 's/^\(CONFIG_CROSS_COMPILER_PREFIX=\).*/\1""/' configs/mingw*
+
+        make -j$(nproc) mingw64_defconfig
+    - name: build busybox.exe
+      shell: bash
+      run: make -j$(nproc) busybox.exe
+    - name: upload busybox artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: busybox
+        path: busybox.exe

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Config.in
 #
 # Never ignore these
 #
+!.github
 !.gitignore
 
 #


### PR DESCRIPTION
This will automatically compile BusyBox-w32 with MSYS2 (see the green check mark, or sometimes the red `x`, next to the commit). Or, more precisely, with a minimal subset of Git for Windows' SDK (because it is now conveniently available as a GitHub Action).

For good measure, it also offers the just-built `busybox.exe` as a build artifact.