### PR TITLE
powershell chcp 65001 but ConsoleOutputCP is 936

### DIFF
--- a/libbb/appletlib.c
+++ b/libbb/appletlib.c
@@ -1235,8 +1235,11 @@ int main(int argc UNUSED_PARAM, char **argv)
 #endif
 {
 #ifdef _WIN32
-	SetConsoleCP(65001);
-	SetConsoleOutputCP(65001);
+	UINT cp = GetConsoleCP();
+	UINT output_cp = GetConsoleOutputCP();
+	if (cp != output_cp) {
+		SetConsoleOutputCP(cp);
+	}
 #endif
 #if 0
 	/* TODO: find a use for a block of memory between end of .bss

--- a/libbb/appletlib.c
+++ b/libbb/appletlib.c
@@ -1234,6 +1234,10 @@ int lbb_main(char **argv)
 int main(int argc UNUSED_PARAM, char **argv)
 #endif
 {
+#ifdef _WIN32
+	SetConsoleCP(65001);
+	SetConsoleOutputCP(65001);
+#endif
 #if 0
 	/* TODO: find a use for a block of memory between end of .bss
 	 * and end of page. For example, I'm getting "_end:0x812e698 2408 bytes"


### PR DESCRIPTION
## download

```sh
curl -L https://frippery.org/files/busybox/busybox64.exe -o busybox.exe
curl -L https://github.com/zeromake/dotfiles/releases/download/v0.1.0/busybox.exe -o busybox-utf8.exe
```
## on powershell
``` powershell
❯ chcp 936
活动代码页: 936
# use busybox-w32
❯ .\busybox.exe cat .\gbk.txt
123abc测试
❯ .\busybox.exe cat .\sj.txt
123abc傾僥僀儞
❯ .\busybox.exe cat .\utf8.txt
123abc娴嬭瘯銈儐銈ゃ兂
# use utf8
❯ .\busybox-utf8.exe cat .\gbk.txt
123abc���
VulkanTutorialCN-master
❯ .\busybox-utf8.exe cat .\sj.txt t
123abc�A�e�C��
VulkanTutorialCN-master
❯ .\busybox-utf8.exe cat .\utf8.txt
123abc测试アテイン
```

## on cmd
``` cmd
> chcp 936
>.\busybox.exe cat .\gbk.txt
123abc测试
>.\busybox.exe cat .\sj.txt
123abc傾僥僀儞
>.\busybox.exe cat .\utf8.txt
123abc娴嬭瘯銈儐銈ゃ兂
>.\busybox-utf8.exe cat .\gbk.txt
123abc���
>.\busybox-utf8.exe cat .\sj.txt
�123abc�A�e�C��
>.\busybox-utf8.exe cat .\utf8.txt
123abc测试アテイン
```

