### PR TITLE
win32: UTF8 console input: don't spin the CPU

### DIFF
--- a/win32/winansi.c
+++ b/win32/winansi.c
@@ -1314,9 +1314,11 @@ BOOL readConsoleInput_utf8(HANDLE h, INPUT_RECORD *r, DWORD len, DWORD *got)
 	if (u8pos == u8len) {
 		DWORD codepoint;
 
-		// peek rather than read to keep the last processed record at
-		// the console queue until we deliver all of its products, so
-		// that WaitForSingleObject(handle) shows there's data ready.
+		// wait-and-peek rather than read to keep the last processed record
+		// at the console queue until we deliver all of its products, so
+		// that external WaitForSingleObject(h) shows there's data ready.
+		if (WaitForSingleObject(h, INFINITE) != WAIT_OBJECT_0)
+			return FALSE;
 		if (!PeekConsoleInputW(h, r, 1, got))
 			return FALSE;
 		if (*got == 0)


### PR DESCRIPTION
Description of the regression is at the commit message.

While we're at this subject, friendly reminder to remove the euro input and euro feature except the CP change.

And consider changing the console CP to ACP, similar to what the euro feature does but better. It should fix all mismatches between the console CP and ACP on all systems, including replacing the euro fix, and could also get rid of the conversions as long as the CP doesn't change.

Alternatively, consider using a `readConsoleInput_acp` variant which simply bypasses the input CP and delivers bytes in ACP regardless of the console CP. That should be simple, and equivalent to changing the input CP to ACP, and would get rid of the input conversion unconditionally, because it simply doesn't depend the input CP anymore.