### PR TITLE
win32: UTF8_INPUT: fix combining of some surrogates pairs

### DIFF
--- a/win32/winansi.c
+++ b/win32/winansi.c
@@ -1276,7 +1276,7 @@ static void maybeEatUpto2ndHalfUp(HANDLE h, DWORD *ph1)
 
 		// got 2nd-half-up. eat the events up to this, combine the values
 		ReadConsoleInputW(h, r, i, &got);
-		*ph1 = 0x10000 | ((*ph1 & ~0xD800) << 10) | (h2 & ~0xDC00);
+		*ph1 = 0x10000 + (((*ph1 & ~0xD800) << 10) | (h2 & ~0xDC00));
 		return;
 	}
 }


### PR DESCRIPTION
The construction of a codepoint from a surrogates pair was incorrect when the result should have had the 0x10000 bit unset, due to logical "|" instead of arithmetic "+" of 0x10000 (so the 0x10000 bit was set incorrectly when the result should have been U+[1]{0,2,4...C,E}XXXX).

For instance: typing or pasting U+20000 𠀀