### PR TITLE
win32: UTF8_OUTPUT: flush stream before conversion

### DIFF
--- a/win32/winansi.c
+++ b/win32/winansi.c
@@ -1590,8 +1590,10 @@ static int conv_fwriteCon(FILE *stream, char *buf, size_t siz)
 {
 	if (conout_conv_enabled()) {
 #if ENABLE_FEATURE_UTF8_OUTPUT
-		if (GetConsoleOutputCP() != CP_UTF8)
+		if (GetConsoleOutputCP() != CP_UTF8) {
+			fflush(stream);  // writeCon_utf8 is unbuffered
 			return writeCon_utf8(fileno(stream), buf, siz) ? EOF : 0;
+		}
 #else
 		charToConBuffA(buf, siz);
 #endif

--- a/win32/winansi.c
+++ b/win32/winansi.c
@@ -850,13 +850,7 @@ static int ansi_emulate(const char *s, FILE *stream)
 
 int winansi_putchar(int c)
 {
-	char t = c;
-	char *s = &t;
-
-	if (!is_console(STDOUT_FILENO))
-		return putchar(c);
-
-	return conv_fwriteCon(stdout, s, 1) == EOF ? EOF : (unsigned char)c;
+	return winansi_fputc(c, stdout);
 }
 
 int winansi_puts(const char *s)
@@ -947,7 +941,7 @@ int winansi_fputc(int c, FILE *stream)
 	char t = c;
 	char *s = &t;
 
-	if (!is_console(fileno(stream))) {
+	if ((unsigned char)c <= 0x7f || !is_console(fileno(stream))) {
 		SetLastError(0);
 		if ((ret=fputc(c, stream)) == EOF)
 			check_pipe(stream);


### PR DESCRIPTION
Fix incorrect output order with a buffered stream which is only partially converted as UTF-8, as described here https://github.com/rmyorston/busybox-w32/issues/396#issuecomment-2041060417 .