### PR TITLE
Use builtin ffs also with GCC

### DIFF
--- a/include/mingw.h
+++ b/include/mingw.h
@@ -248,7 +248,7 @@ int strverscmp(const char *s1, const char *s2);
 /*
  * strings.h
  */
-#if !defined(__clang__)
+#if !defined(__GNUC__)
 int ffs(int i);
 #else
 # define ffs(i) __builtin_ffs(i)


### PR DESCRIPTION
With `CONFIG_DEBUG_PESSIMIZE=y` (`-O0`) the `ffs()` intrinsic is left as a function call, resulting in a linker error. The prefixed builtin is generally part of the "GNU C" dialect and is usable in any "GNU C" implementation, i.e. any compiler that defines `__GNUC__`. That includes Clang, GCC, and more.

* * *

I always use `CONFIG_DEBUG_PESSIMIZE=y` when hacking on busyboxy-w32 in w64devkit, and I've made this temporary change dozens of times. It's about time I just upstream it!