### PR TITLE
tls: fix schannel handshake on older Windows

### DIFF
--- a/networking/tls.c
+++ b/networking/tls.c
@@ -3015,7 +3015,7 @@ void FAST_FUNC tls_handshake(tls_state_t * state, const char *hostname) {
 										in_buffers[1].cbBuffer),
 					in_buffers[1].cbBuffer);
 			state->in_buffer_size = in_buffers[1].cbBuffer;
-		} else if (in_buffers[1].BufferType != SECBUFFER_MISSING) {
+		} else if (status != SEC_E_INCOMPLETE_MESSAGE) {
 			state->in_buffer_size = 0;
 		}
 


### PR DESCRIPTION
I noticed on older Windows versions, `InitializeSecurityContext` didn't return a `SECBUFFER_MISSING` to indicate that more data is to be read, so I replaced it with a functionally equivalent check.