### PR TITLE
Do not open hidden files for executability

### DIFF
--- a/win32/mingw.c
+++ b/win32/mingw.c
@@ -729,6 +729,7 @@ static int do_lstat(int follow, const char *file_name, struct mingw_stat *buf)
 			if (S_ISREG(buf->st_mode) &&
 					(has_exe_suffix(file_name) ||
 					(!(buf->st_attr & FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS) &&
+					 !(buf->st_attr & FILE_ATTRIBUTE_HIDDEN) &&
 						has_exec_format(file_name))))
 				buf->st_mode |= S_IXUSR|S_IXGRP|S_IXOTH;
 			buf->st_size = fdata.nFileSizeLow |


### PR DESCRIPTION
When executing `ls` in the home directory and with Cortex XDR installed,
the program is aborted and quarantined. This is because busybox-w32
tries to open all files in the directory, including hidden ones, while Cortex
creates some random files hidden files.

I really like the rule `busybox-w32` uses for distinguishing executable files.
I find the `starts with #!` rule very clever and useful, as it helps avoid
permission issues in Windows. I would like to extend that rule to `Visible
files that start with #!`.

Cortex XDR creates some random files in the user's `USERPROFILE` directory,
as well as in subdirectories like Documents, Music, and others. It's a
frustrating program, but unfortunately unavoidable in some corporate
environments.