### PR TITLE
md5/sha1sum: Honor the -b flag in the output

### DIFF
--- a/coreutils/md5_sha1_sum.c
+++ b/coreutils/md5_sha1_sum.c
@@ -159,6 +159,7 @@ enum {
 #define FLAG_SILENT  1
 #define FLAG_CHECK   2
 #define FLAG_WARN    4
+#define FLAG_BINARY  8
 
 /* This might be useful elsewhere */
 static unsigned char *hash_bin_to_hex(unsigned char *hash_value,
@@ -277,13 +278,15 @@ int md5_sha1_sum_main(int argc UNUSED_PARAM, char **argv)
 {
 	unsigned char *in_buf;
 	int return_value = EXIT_SUCCESS;
-	unsigned flags;
+	unsigned flags = 0;
 #if ENABLE_SHA3SUM
 	unsigned sha3_width = 224;
 #endif
 
 	if (ENABLE_FEATURE_MD5_SHA1_SUM_CHECK) {
-		/* -b "binary", -t "text" are ignored (shaNNNsum compat) */
+		/* -b "binary", -t "text" are mostly ignored (shaNNNsum compat);
+		 * the -b flag does set the '*' mode char in the output though, but
+		 * the -t flag doesn't override it. */
 		/* -s and -w require -c */
 #if ENABLE_SHA3SUM
 		if (applet_name[3] == HASH_SHA3 && (!ENABLE_SHA384SUM || applet_name[4] != '8'))
@@ -375,7 +378,7 @@ int md5_sha1_sum_main(int argc UNUSED_PARAM, char **argv)
 			if (hash_value == NULL) {
 				return_value = EXIT_FAILURE;
 			} else {
-				printf("%s  %s\n", hash_value, *argv);
+				printf("%s %c%s\n", hash_value, flags & FLAG_BINARY ? '*' : ' ', *argv);
 				free(hash_value);
 			}
 		}

--- a/testsuite/sha1sum.tests
+++ b/testsuite/sha1sum.tests
@@ -9,6 +9,10 @@ testing "sha1sum: one-space separated input for -c" \
 	'echo "da39a3ee5e6b4b0d3255bfef95601890afd80709 EMPTY" | sha1sum -c' \
 	"EMPTY: OK\n" \
 	"" ""
+testing "sha1sum: -b flag in output" \
+	'sha1sum -b EMPTY' \
+	"da39a3ee5e6b4b0d3255bfef95601890afd80709 *EMPTY\n" \
+	"" ""
 SKIP=
 rm EMPTY
 


### PR DESCRIPTION
The output of md5sum/sha1sum contains a character to indicate what mode was used to read the file - '*' for binary, and ' ' for text or where binary is insignificant.

This flag character makes a difference for the ffmpeg testsuite. This testsuite contains a number of reference files (e.g. [1]), containing the expected md5sum output for those files, which is checked verbatim.

By making busybox's md5sum honor this flag in the output, ffmpeg's testsuite can run successfully on top of busybox.

The flag is only partially implemented; in coreutils md5sum, a later "-t" option overrides an earlier "-b" option. Here, just check if a "-b" option was specified or not. Neither flag affects how the files actually are read.

[1] https://code.ffmpeg.org/FFmpeg/FFmpeg/src/commit/894da5ca7d742e4429ffb2af534fcda0103ef593/tests/ref/acodec/flac

---
This patch isn't Windows specific in any way, so I've sent it upstream first - at https://lists.busybox.net/pipermail/busybox/2025-December/091851.html - but progress there is kinda slow. If you'd be ok with taking it on despite that, it'd be very much appreciated! That would open the door for using busybox-w32 for building and running ffmpeg's tests instead of msys2.