### PR TITLE
libbb: refactor CNG hashing implementation

### DIFF
--- a/networking/tls.c
+++ b/networking/tls.c
@@ -440,6 +440,7 @@ static void prf_hmac_sha256(/*tls_state_t *tls,*/
 		/* A(2) = HMAC_hash(secret, A(1)) */
 		hmac_peek_hash(&ctx, a, A, NULL);
 	}
+	hmac_uninit(&ctx);
 #undef A
 #undef SECRET
 #undef SEED


### PR DESCRIPTION
The current CNG implementation only supports Windows 10 due to the use of [CNG pseudo-handles](https://learn.microsoft.com/en-us/windows/win32/seccng/cng-algorithm-pseudo-handles) in place of normally instantiated [algorithm providers](https://learn.microsoft.com/en-us/windows/win32/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider). Said pseudo-handles only work on Windows 10 and above. When I initially programmed the implementation, I took the easy way out and used them out of fear of having to manage global state. After the recent introduction of busybox-w32 into the [llvm-mingw](https://github.com/mstorsjo/llvm-mingw/blob/master/build-busybox.sh) project, which I personally use, I have decided to bite the bullet and implement it properly. I also fixed some major bugs in the rare case where CNG support is enabled but not Schannel (which thankfully does not occur in any of the default build configurations). 

If global state is not preferred, there is an alternative: creating and freeing the algorithm providers along with the hash state. But, as mentioned in Microsoft's documentation, doing this is fairly slow and it is recommended that this practice be avoided. 