### PR TITLE
win32: support long paths (> 260 chars) in file operations

### DIFF
--- a/testsuite/ansi-mode/ansi-long-path
+++ b/testsuite/ansi-mode/ansi-long-path
@@ -1,0 +1,32 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test long paths work in ANSI mode (no UTF-8 manifest)
+
+ANSI_BUSYBOX="$bindir/busybox-ansi.exe"
+BASEDIR=c:/temp/ansi_long_test$$
+D=longdirname_12345
+
+test -f "$ANSI_BUSYBOX" || { echo "Run setup-ansi-test first"; exit 1; }
+
+# Create deep directory
+powershell.exe -Command "
+\$d = '$D'
+\$path = '$BASEDIR'
+for (\$i = 0; \$i -lt 15; \$i++) { \$path = Join-Path \$path \$d }
+New-Item -Path \$path -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path \$path 'testfile.txt') -ItemType File -Force | Out-Null
+Write-Host \$path
+" > deeppath.txt
+
+DEEPPATH=$(cat deeppath.txt | tr '\\' '/' | tr -d '\r')
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+
+# Test ls with ANSI-mode busybox
+output=$("$ANSI_BUSYBOX" ls -la "$DEEPPATH" 2>&1)
+echo "$output" | grep -q testfile.txt || { echo "ls failed: $output"; exit 1; }
+
+# Test rm
+"$ANSI_BUSYBOX" rm -rf "$BASEDIR"
+test ! -d "$BASEDIR" || { echo "rm -rf failed"; exit 1; }
+
+rm -f deeppath.txt

--- a/testsuite/ansi-mode/ansi-nonascii-path
+++ b/testsuite/ansi-mode/ansi-nonascii-path
@@ -1,0 +1,28 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test non-ASCII paths work in ANSI mode (no UTF-8 manifest)
+
+ANSI_BUSYBOX="$bindir/busybox-ansi.exe"
+BASEDIR=c:/temp/ansi_path_test$$
+
+# Ensure ANSI busybox exists (run setup-ansi-test first)
+test -f "$ANSI_BUSYBOX" || { echo "Run setup-ansi-test first"; exit 1; }
+
+# Create directory with CP1252-compatible accented character
+# e-acute = U+00E9
+powershell.exe -Command "
+\$e = [char]0x00e9
+New-Item -Path \"$BASEDIR/caf\`\${e}_dir\" -ItemType Directory -Force | Out-Null
+New-Item -Path \"$BASEDIR/caf\`\${e}_dir/file.txt\" -ItemType File -Force | Out-Null
+"
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+
+# Test ls with ANSI-mode busybox
+output=$("$ANSI_BUSYBOX" ls "$BASEDIR" 2>&1)
+echo "$output" | grep -q "caf.*_dir" || { echo "ls failed: $output"; exit 1; }
+
+# Test stat
+"$ANSI_BUSYBOX" stat "$BASEDIR" > /dev/null 2>&1 || { echo "stat failed"; exit 1; }
+
+# Cleanup
+"$ANSI_BUSYBOX" rm -rf "$BASEDIR"

--- a/testsuite/ansi-mode/ansi-printable-chars
+++ b/testsuite/ansi-mode/ansi-printable-chars
@@ -1,0 +1,26 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test printable chars handling in ANSI mode (commit 8bd8100)
+# Bytes > 127 should be printable in ANSI code page, not replaced with '?'
+
+ANSI_BUSYBOX="$bindir/busybox-ansi.exe"
+BASEDIR=c:/temp/ansi_print_test$$
+
+test -f "$ANSI_BUSYBOX" || { echo "Run setup-ansi-test first"; exit 1; }
+
+# Create file with accented char (e-acute = 0xE9 in CP1252, valid byte > 127)
+powershell.exe -Command "
+\$e = [char]0x00e9
+New-Item -Path '$BASEDIR' -ItemType Directory -Force | Out-Null
+New-Item -Path \"$BASEDIR/caf\`\${e}.txt\" -ItemType File -Force | Out-Null
+"
+
+test -d "$BASEDIR" || { echo "setup failed"; exit 1; }
+
+# In ANSI mode, ls should NOT replace the accented char with '?'
+output=$("$ANSI_BUSYBOX" ls "$BASEDIR" 2>&1)
+
+# Verify filename appears (with some form of the accented char, not '?')
+echo "$output" | grep -q 'caf..*\.txt' || { echo "filename not found: $output"; exit 1; }
+echo "$output" | grep -q 'caf?\.txt' && { echo "char wrongly replaced with ?: $output"; exit 1; }
+
+"$ANSI_BUSYBOX" rm -rf "$BASEDIR"

--- a/testsuite/ansi-mode/setup-ansi-test
+++ b/testsuite/ansi-mode/setup-ansi-test
@@ -1,0 +1,29 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Setup script for ANSI mode testing - downloads perc and creates manifest-stripped binary
+# This tests code page handling when UTF-8 manifest is not in effect (Win XP/7/8 behavior)
+
+PERC_URL="https://github.com/avih/perc/releases/download/v0.1/perc64.exe"
+PERC_PATH="c:/temp/perc.exe"
+ANSI_BUSYBOX="$bindir/busybox-ansi.exe"
+
+# Download perc if not present
+if [ ! -f "$PERC_PATH" ]; then
+	echo "Downloading perc..."
+	powershell.exe -Command "Invoke-WebRequest -Uri '$PERC_URL' -OutFile '$PERC_PATH'" || {
+		echo "Failed to download perc"
+		exit 1
+	}
+fi
+
+# Create ANSI-mode busybox by stripping the UTF-8 manifest
+if [ ! -f "$ANSI_BUSYBOX" ] || [ "$bindir/busybox.exe" -nt "$ANSI_BUSYBOX" ]; then
+	echo "Creating ANSI-mode busybox (stripping UTF-8 manifest)..."
+	cp "$bindir/busybox.exe" "$ANSI_BUSYBOX"
+	"$PERC_PATH" -D -t MANIFEST "$ANSI_BUSYBOX" || {
+		echo "Failed to strip manifest"
+		rm -f "$ANSI_BUSYBOX"
+		exit 1
+	}
+fi
+
+echo "ANSI test setup complete: $ANSI_BUSYBOX"

--- a/testsuite/ls/ls-long-nonascii-path-works
+++ b/testsuite/ls/ls-long-nonascii-path-works
@@ -1,0 +1,24 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test long paths with non-ASCII characters
+
+BASEDIR=c:/temp/ls_long_nonascii_test$$
+
+# Create deep path with accented directory names
+# e-acute = U+00E9, valid in both UTF-8 and CP1252
+powershell.exe -Command "
+\$e = [char]0x00e9
+\$d = \"caf\`\${e}_dir_1234\"
+\$path = '$BASEDIR'
+for (\$i = 0; \$i -lt 15; \$i++) { \$path = Join-Path \$path \$d }
+New-Item -Path \$path -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path \$path 'testfile.txt') -ItemType File -Force | Out-Null
+Write-Host \$path
+" > deeppath.txt
+
+DEEPPATH=$(cat deeppath.txt | tr '\\' '/' | tr -d '\r')
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+output=$(busybox ls -la "$DEEPPATH" 2>&1)
+echo "$output" | grep -q testfile.txt || { echo "ls failed: $output"; exit 1; }
+busybox rm -rf "$BASEDIR"
+rm -f deeppath.txt

--- a/testsuite/ls/ls-long-path-error-preserves-path
+++ b/testsuite/ls/ls-long-path-error-preserves-path
@@ -3,7 +3,7 @@
 
 LONGPATH="c:/temp/nonexistent_path/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345"
 
-output=$(busybox ls "$LONGPATH" 2>&1) && exit 1
+output=$("$d/busybox" ls "$LONGPATH" 2>&1) && exit 1
 echo "$output" | grep -q "$LONGPATH" || { echo "path not in error: $output"; exit 1; }
 echo "$output" | grep -q '\\\\?\\\|\\?\' && { echo "internal path leaked: $output"; exit 1; }
 true

--- a/testsuite/ls/ls-long-path-error-preserves-path
+++ b/testsuite/ls/ls-long-path-error-preserves-path
@@ -1,0 +1,9 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# error messages should show user's path, not internal \\?\ prefixed path
+
+LONGPATH="c:/temp/nonexistent_path/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345"
+
+output=$(busybox ls "$LONGPATH" 2>&1) && exit 1
+echo "$output" | grep -q "$LONGPATH" || { echo "path not in error: $output"; exit 1; }
+echo "$output" | grep -q '\\\\?\\\|\\?\' && { echo "internal path leaked: $output"; exit 1; }
+true

--- a/testsuite/ls/ls-long-path-with-dotdot
+++ b/testsuite/ls/ls-long-path-with-dotdot
@@ -1,0 +1,31 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test long paths with .. components are resolved correctly
+
+BASEDIR=c:/temp/ls_longdotdot_test$$
+D=longdirname_12345
+
+# Create deep directory structure
+powershell.exe -Command "
+\$d = '$D'
+\$path = '$BASEDIR'
+for (\$i = 0; \$i -lt 15; \$i++) { \$path = Join-Path \$path \$d }
+New-Item -Path \$path -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path \$path 'target.txt') -ItemType File -Force | Out-Null
+# Create a sibling directory at depth 14
+\$sibling = '$BASEDIR'
+for (\$i = 0; \$i -lt 14; \$i++) { \$sibling = Join-Path \$sibling \$d }
+\$sibling = Join-Path \$sibling 'sibling'
+New-Item -Path \$sibling -ItemType Directory -Force | Out-Null
+Write-Host \$sibling
+" > siblingpath.txt
+
+SIBLINGPATH=$(cat siblingpath.txt | tr '\\' '/' | tr -d '\r')
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+
+# Access the deep directory via sibling/../$D which should resolve the .. component
+output=$(busybox ls "$SIBLINGPATH/../$D" 2>&1)
+echo "$output" | grep -q "target.txt" || { echo "long path with .. failed: $output"; exit 1; }
+
+busybox rm -rf "$BASEDIR"
+rm -f siblingpath.txt

--- a/testsuite/ls/ls-long-path-works
+++ b/testsuite/ls/ls-long-path-works
@@ -15,7 +15,7 @@ Write-Host \$path
 DEEPPATH=$(cat deeppath.txt | tr '\\' '/' | tr -d '\r')
 
 test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
-output=$(busybox ls -la "$DEEPPATH" 2>&1)
+output=$("$d/busybox" ls -la "$DEEPPATH" 2>&1)
 echo "$output" | grep -q testfile.txt || { echo "ls failed: $output"; exit 1; }
-busybox rm -rf "$BASEDIR"
+"$d/busybox" rm -rf "$BASEDIR"
 rm -f deeppath.txt

--- a/testsuite/ls/ls-long-path-works
+++ b/testsuite/ls/ls-long-path-works
@@ -1,0 +1,21 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+
+BASEDIR=c:/temp/ls_longpath_test$$
+D=longdirname_12345
+
+powershell.exe -Command "
+\$d = '$D'
+\$path = '$BASEDIR'
+for (\$i = 0; \$i -lt 15; \$i++) { \$path = Join-Path \$path \$d }
+New-Item -Path \$path -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path \$path 'testfile.txt') -ItemType File -Force | Out-Null
+Write-Host \$path
+" > deeppath.txt
+
+DEEPPATH=$(cat deeppath.txt | tr '\\' '/' | tr -d '\r')
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+output=$(busybox ls -la "$DEEPPATH" 2>&1)
+echo "$output" | grep -q testfile.txt || { echo "ls failed: $output"; exit 1; }
+busybox rm -rf "$BASEDIR"
+rm -f deeppath.txt

--- a/testsuite/ls/ls-mixed-slashes
+++ b/testsuite/ls/ls-mixed-slashes
@@ -1,0 +1,18 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test paths with mixed forward and backslashes
+
+BASEDIR=c:/temp/ls_mixslash_test$$
+
+powershell.exe -Command "
+New-Item -Path '$BASEDIR/a/b/c/d' -ItemType Directory -Force | Out-Null
+New-Item -Path '$BASEDIR/a/b/c/d/file.txt' -ItemType File -Force | Out-Null
+"
+
+test -d "$BASEDIR" || { echo "setup failed"; exit 1; }
+
+# Various mixed slash combinations
+busybox ls "$BASEDIR\\a/b\\c/d" | grep -q file.txt || { echo "mix1 failed"; exit 1; }
+busybox ls "$BASEDIR/a\\b/c\\d" | grep -q file.txt || { echo "mix2 failed"; exit 1; }
+busybox ls "c:\\temp\\ls_mixslash_test$$/a/b/c/d" | grep -q file.txt || { echo "mix3 failed"; exit 1; }
+
+busybox rm -rf "$BASEDIR"

--- a/testsuite/ls/ls-nonascii-path-works
+++ b/testsuite/ls/ls-nonascii-path-works
@@ -1,0 +1,19 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test non-ASCII characters in paths (common to CP1252 and UTF-8)
+
+BASEDIR=c:/temp/ls_nonascii_test$$
+
+# Use PowerShell to create directory with accented characters
+# e-acute = U+00E9, valid in both UTF-8 and common ANSI code pages (CP1252)
+powershell.exe -Command "
+\$e = [char]0x00e9
+\$path = \"$BASEDIR/caf\`\${e}_test\"
+New-Item -Path \$path -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path \$path 'file.txt') -ItemType File -Force | Out-Null
+"
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+output=$(busybox ls "$BASEDIR" 2>&1)
+# Check that we see the directory name with something after 'caf'
+echo "$output" | grep -q "caf.*_test" || { echo "ls failed: $output"; exit 1; }
+busybox rm -rf "$BASEDIR"

--- a/testsuite/ls/ls-path-formats
+++ b/testsuite/ls/ls-path-formats
@@ -1,0 +1,37 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test various Windows path formats still work with wide API changes
+# See README.md for path format documentation
+
+BASEDIR=c:/temp/ls_pathfmt_test$$
+
+# Setup test directory structure
+powershell.exe -Command "
+New-Item -Path '$BASEDIR/subdir/nested' -ItemType Directory -Force | Out-Null
+New-Item -Path '$BASEDIR/subdir/file.txt' -ItemType File -Force | Out-Null
+New-Item -Path '$BASEDIR/subdir/nested/deep.txt' -ItemType File -Force | Out-Null
+"
+
+test -d "$BASEDIR" || { echo "setup failed"; exit 1; }
+
+# Test 1: Absolute path with forward slashes
+output=$(busybox ls "$BASEDIR/subdir" 2>&1)
+echo "$output" | grep -q "file.txt" || { echo "absolute path failed: $output"; exit 1; }
+
+# Test 2: Path with .. components
+output=$(busybox ls "$BASEDIR/subdir/nested/../" 2>&1)
+echo "$output" | grep -q "file.txt" || { echo "path with .. failed: $output"; exit 1; }
+
+# Test 3: Path with multiple .. components
+output=$(busybox ls "$BASEDIR/subdir/nested/../../subdir" 2>&1)
+echo "$output" | grep -q "file.txt" || { echo "multiple .. failed: $output"; exit 1; }
+
+# Test 4: Absolute path with backslashes (via variable to avoid shell escaping)
+BSPATH=$(echo "$BASEDIR/subdir" | tr '/' '\\')
+output=$(busybox ls "$BSPATH" 2>&1)
+echo "$output" | grep -q "file.txt" || { echo "backslash path failed: $output"; exit 1; }
+
+# Test 5: Mixed slashes
+output=$(busybox ls "$BASEDIR\\subdir/nested" 2>&1)
+echo "$output" | grep -q "deep.txt" || { echo "mixed slashes failed: $output"; exit 1; }
+
+busybox rm -rf "$BASEDIR"

--- a/testsuite/ls/ls-printable-nonascii
+++ b/testsuite/ls/ls-printable-nonascii
@@ -1,0 +1,25 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test that non-ASCII chars in filenames are displayed, not replaced with '?'
+# Related: commit 8bd8100 - printable chars handling for non-UTF8 code pages
+
+BASEDIR=c:/temp/ls_printable_test$$
+
+# Create file with accented character using PowerShell [char] syntax
+# e-acute = U+00E9, valid in UTF-8 and CP1252
+powershell.exe -Command "
+New-Item -Path '$BASEDIR' -ItemType Directory -Force | Out-Null
+\$e = [char]0x00e9
+New-Item -Path \"$BASEDIR/caf\`\${e}.txt\" -ItemType File -Force | Out-Null
+"
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+
+# ls should show the actual filename, not 'caf?.txt'
+output=$(busybox ls "$BASEDIR" 2>&1)
+
+# Check that we see something like 'café.txt' and not 'caf?.txt'
+# The filename should contain 'caf' followed by something and '.txt'
+echo "$output" | grep -q 'caf..*\.txt' || { echo "filename not found: $output"; exit 1; }
+echo "$output" | grep -q 'caf?\.txt' && { echo "char replaced with ?: $output"; exit 1; }
+
+busybox rm -rf "$BASEDIR"

--- a/testsuite/ls/ls-relative-path
+++ b/testsuite/ls/ls-relative-path
@@ -1,0 +1,27 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test relative paths work correctly
+
+BASEDIR=c:/temp/ls_relative_test$$
+
+powershell.exe -Command "
+New-Item -Path '$BASEDIR/a/b/c' -ItemType Directory -Force | Out-Null
+New-Item -Path '$BASEDIR/a/b/c/file.txt' -ItemType File -Force | Out-Null
+"
+
+test -d "$BASEDIR" || { echo "setup failed"; exit 1; }
+
+# Save current directory and change to test directory
+ORIGDIR=$(pwd)
+cd "$BASEDIR"
+
+# Test relative path from BASEDIR
+output=$(busybox ls "a/b/c" 2>&1)
+echo "$output" | grep -q "file.txt" || { cd "$ORIGDIR"; echo "relative path failed: $output"; exit 1; }
+
+# Test relative path with ..
+cd "$BASEDIR/a/b"
+output=$(busybox ls "../b/c" 2>&1)
+echo "$output" | grep -q "file.txt" || { cd "$ORIGDIR"; echo "relative with .. failed: $output"; exit 1; }
+
+cd "$ORIGDIR"
+busybox rm -rf "$BASEDIR"

--- a/testsuite/ls/ls-root-relative-path
+++ b/testsuite/ls/ls-root-relative-path
@@ -1,0 +1,18 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test /path format (relative to current drive root)
+
+BASEDIR=/temp/ls_rootrel_test$$
+
+# Create using absolute path but test with root-relative
+powershell.exe -Command "
+New-Item -Path 'C:$BASEDIR/subdir' -ItemType Directory -Force | Out-Null
+New-Item -Path 'C:$BASEDIR/subdir/file.txt' -ItemType File -Force | Out-Null
+"
+
+test -d "c:$BASEDIR" || { echo "setup failed"; exit 1; }
+
+# Test /path format (should resolve to C:/temp/...)
+output=$(busybox ls "$BASEDIR/subdir" 2>&1)
+echo "$output" | grep -q "file.txt" || { echo "root-relative path failed: $output"; exit 1; }
+
+busybox rm -rf "c:$BASEDIR"

--- a/testsuite/rm/rm-long-path-error-preserves-path
+++ b/testsuite/rm/rm-long-path-error-preserves-path
@@ -3,7 +3,7 @@
 
 LONGPATH="c:/temp/nonexistent_path/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/file.txt"
 
-output=$(busybox rm "$LONGPATH" 2>&1) && exit 1
+output=$("$d/busybox" rm "$LONGPATH" 2>&1) && exit 1
 echo "$output" | grep -q "$LONGPATH" || { echo "path not in error: $output"; exit 1; }
 echo "$output" | grep -q '\\\\?\\\|\\?\' && { echo "internal path leaked: $output"; exit 1; }
 true

--- a/testsuite/rm/rm-long-path-error-preserves-path
+++ b/testsuite/rm/rm-long-path-error-preserves-path
@@ -1,0 +1,9 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# error messages should show user's path, not internal \\?\ prefixed path
+
+LONGPATH="c:/temp/nonexistent_path/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/file.txt"
+
+output=$(busybox rm "$LONGPATH" 2>&1) && exit 1
+echo "$output" | grep -q "$LONGPATH" || { echo "path not in error: $output"; exit 1; }
+echo "$output" | grep -q '\\\\?\\\|\\?\' && { echo "internal path leaked: $output"; exit 1; }
+true

--- a/testsuite/rm/rm-nonascii-path-works
+++ b/testsuite/rm/rm-nonascii-path-works
@@ -1,0 +1,16 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test rm with non-ASCII characters in paths
+
+BASEDIR=c:/temp/rm_nonascii_test$$
+
+# e-acute = U+00E9, valid in both UTF-8 and CP1252
+powershell.exe -Command "
+\$e = [char]0x00e9
+\$path = \"$BASEDIR/caf\`\${e}_to_delete\"
+New-Item -Path \$path -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path \$path 'file.txt') -ItemType File -Force | Out-Null
+"
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+busybox rm -rf "$BASEDIR"
+test ! -d "$BASEDIR"

--- a/testsuite/rm/rm-removes-long-path
+++ b/testsuite/rm/rm-removes-long-path
@@ -13,5 +13,5 @@ New-Item -Path (Join-Path \$path 'testfile.txt') -ItemType File -Force | Out-Nul
 "
 
 test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
-busybox rm -rf "$BASEDIR"
+"$d/busybox" rm -rf "$BASEDIR"
 test ! -d "$BASEDIR"

--- a/testsuite/rm/rm-removes-long-path
+++ b/testsuite/rm/rm-removes-long-path
@@ -1,0 +1,17 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+
+BASEDIR=c:/temp/rm_longpath_test$$
+D=longdirname_12345
+
+# create deep directory with PowerShell
+powershell.exe -Command "
+\$d = '$D'
+\$path = '$BASEDIR'
+for (\$i = 0; \$i -lt 15; \$i++) { \$path = Join-Path \$path \$d }
+New-Item -Path \$path -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path \$path 'testfile.txt') -ItemType File -Force | Out-Null
+"
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+busybox rm -rf "$BASEDIR"
+test ! -d "$BASEDIR"

--- a/testsuite/stat/stat-long-path-error-preserves-path
+++ b/testsuite/stat/stat-long-path-error-preserves-path
@@ -3,7 +3,7 @@
 
 LONGPATH="c:/temp/nonexistent_path/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/file.txt"
 
-output=$(busybox stat "$LONGPATH" 2>&1) && exit 1
+output=$("$d/busybox" stat "$LONGPATH" 2>&1) && exit 1
 echo "$output" | grep -q "$LONGPATH" || { echo "path not in error: $output"; exit 1; }
 echo "$output" | grep -q '\\\\?\\\|\\?\' && { echo "internal path leaked: $output"; exit 1; }
 true

--- a/testsuite/stat/stat-long-path-error-preserves-path
+++ b/testsuite/stat/stat-long-path-error-preserves-path
@@ -1,0 +1,9 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# error messages should show user's path, not internal \\?\ prefixed path
+
+LONGPATH="c:/temp/nonexistent_path/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/longdirname_12345/file.txt"
+
+output=$(busybox stat "$LONGPATH" 2>&1) && exit 1
+echo "$output" | grep -q "$LONGPATH" || { echo "path not in error: $output"; exit 1; }
+echo "$output" | grep -q '\\\\?\\\|\\?\' && { echo "internal path leaked: $output"; exit 1; }
+true

--- a/testsuite/stat/stat-long-path-works
+++ b/testsuite/stat/stat-long-path-works
@@ -1,0 +1,21 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+
+BASEDIR=c:/temp/stat_longpath_test$$
+D=longdirname_12345
+
+powershell.exe -Command "
+\$d = '$D'
+\$path = '$BASEDIR'
+for (\$i = 0; \$i -lt 15; \$i++) { \$path = Join-Path \$path \$d }
+New-Item -Path \$path -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path \$path 'testfile.txt') -ItemType File -Force | Out-Null
+Write-Host \$path
+" > deeppath.txt
+
+DEEPPATH=$(cat deeppath.txt | tr '\\' '/' | tr -d '\r')
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+busybox stat "$DEEPPATH/testfile.txt" > /dev/null 2>&1 || { echo "stat failed"; exit 1; }
+busybox stat "$DEEPPATH" > /dev/null 2>&1 || { echo "stat failed on dir"; exit 1; }
+busybox rm -rf "$BASEDIR"
+rm -f deeppath.txt

--- a/testsuite/stat/stat-long-path-works
+++ b/testsuite/stat/stat-long-path-works
@@ -15,7 +15,7 @@ Write-Host \$path
 DEEPPATH=$(cat deeppath.txt | tr '\\' '/' | tr -d '\r')
 
 test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
-busybox stat "$DEEPPATH/testfile.txt" > /dev/null 2>&1 || { echo "stat failed"; exit 1; }
-busybox stat "$DEEPPATH" > /dev/null 2>&1 || { echo "stat failed on dir"; exit 1; }
-busybox rm -rf "$BASEDIR"
+"$d/busybox" stat "$DEEPPATH/testfile.txt" > /dev/null 2>&1 || { echo "stat failed"; exit 1; }
+"$d/busybox" stat "$DEEPPATH" > /dev/null 2>&1 || { echo "stat failed on dir"; exit 1; }
+"$d/busybox" rm -rf "$BASEDIR"
 rm -f deeppath.txt

--- a/testsuite/stat/stat-nonascii-path-works
+++ b/testsuite/stat/stat-nonascii-path-works
@@ -1,0 +1,21 @@
+# FEATURE: CONFIG_PLATFORM_MINGW32
+# Test stat with non-ASCII characters in paths
+
+BASEDIR=c:/temp/stat_nonascii_test$$
+
+# e-acute = U+00E9, valid in both UTF-8 and CP1252
+powershell.exe -Command "
+\$e = [char]0x00e9
+\$path = \"$BASEDIR/caf\`\${e}_dir\"
+New-Item -Path \$path -ItemType Directory -Force | Out-Null
+New-Item -Path (Join-Path \$path 'file.txt') -ItemType File -Force | Out-Null
+Write-Host \$path
+" > testpath.txt
+
+TESTPATH=$(cat testpath.txt | tr '\\' '/' | tr -d '\r')
+
+test -d "$BASEDIR" || { echo "directory creation failed"; exit 1; }
+busybox stat "$TESTPATH" > /dev/null 2>&1 || { echo "stat failed on dir"; exit 1; }
+busybox stat "$TESTPATH/file.txt" > /dev/null 2>&1 || { echo "stat failed on file"; exit 1; }
+busybox rm -rf "$BASEDIR"
+rm -f testpath.txt

--- a/testsuite/stat/stat-works
+++ b/testsuite/stat/stat-works
@@ -1,0 +1,4 @@
+# Basic stat test
+touch testfile
+busybox stat testfile > /dev/null 2>&1
+rm testfile

--- a/win32/dirent.c
+++ b/win32/dirent.c
@@ -1,35 +1,52 @@
 #include "libbb.h"
 
+#define LONG_PATH_MAX 32800
+
+static wchar_t *wide_path_buf;
+static wchar_t *wide_pattern_buf;
+
 struct DIR {
 	struct dirent dd_dir;
 	HANDLE dd_handle;     /* FindFirstFile handle */
 	int not_first;
 	int got_dot;
 	int got_dotdot;
+	int use_wide;
 };
+
+static inline unsigned char get_dtype(DWORD attr, DWORD reserved0)
+{
+	if ((attr & FILE_ATTRIBUTE_REPARSE_POINT) &&
+			(reserved0 == IO_REPARSE_TAG_SYMLINK ||
+			reserved0 == IO_REPARSE_TAG_MOUNT_POINT ||
+			reserved0 == IO_REPARSE_TAG_APPEXECLINK))
+		return DT_LNK;
+	if (attr & FILE_ATTRIBUTE_DIRECTORY)
+		return DT_DIR;
+	return DT_REG;
+}
 
 static inline void finddata2dirent(struct dirent *ent, WIN32_FIND_DATAA *fdata)
 {
 	/* copy file name from WIN32_FIND_DATA to dirent */
 	strcpy(ent->d_name, fdata->cFileName);
+	ent->d_type = get_dtype(fdata->dwFileAttributes, fdata->dwReserved0);
+}
 
-	if ((fdata->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) &&
-			(fdata->dwReserved0 == IO_REPARSE_TAG_SYMLINK ||
-			fdata->dwReserved0 ==  IO_REPARSE_TAG_MOUNT_POINT ||
-			fdata->dwReserved0 ==  IO_REPARSE_TAG_APPEXECLINK))
-		ent->d_type = DT_LNK;
-	else if (fdata->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-		ent->d_type = DT_DIR;
-	else
-		ent->d_type = DT_REG;
+static inline void finddata2dirent_w(struct dirent *ent, WIN32_FIND_DATAW *fdata)
+{
+	WideCharToMultiByte(CP_ACP, 0, fdata->cFileName, -1,
+			ent->d_name, PATH_MAX, NULL, NULL);
+	ent->d_type = get_dtype(fdata->dwFileAttributes, fdata->dwReserved0);
 }
 
 DIR *opendir(const char *name)
 {
 	char pattern[MAX_PATH];
 	WIN32_FIND_DATAA fdata;
+	WIN32_FIND_DATAW fdataw;
 	HANDLE h;
-	int len;
+	int len, use_wide = 0;
 	DIR *dir;
 
 	/* check that name is not NULL */
@@ -37,12 +54,41 @@ DIR *opendir(const char *name)
 		errno = EINVAL;
 		return NULL;
 	}
-	/* check that the pattern won't be too long for FindFirstFileA */
+
 	len = strlen(name);
-	if (len + 2 >= MAX_PATH) {
-		errno = ENAMETOOLONG;
-		return NULL;
+
+	/* use wide API for long paths - need headroom for child names */
+	if (len + 40 >= MAX_PATH) {
+		DWORD wlen;
+
+		if (!wide_path_buf) {
+			wide_path_buf = xmalloc(LONG_PATH_MAX * sizeof(wchar_t));
+			wide_pattern_buf = xmalloc(LONG_PATH_MAX * sizeof(wchar_t));
+		}
+
+		if (MultiByteToWideChar(CP_ACP, 0, name, -1, wide_path_buf, LONG_PATH_MAX) == 0) {
+			errno = EINVAL;
+			return NULL;
+		}
+
+		/* build \\?\<absolute_path>\* pattern using GetFullPathNameW */
+		memcpy(wide_pattern_buf, L"\\\\?\\", 4 * sizeof(wchar_t));
+		wlen = GetFullPathNameW(wide_path_buf, LONG_PATH_MAX - 8, wide_pattern_buf + 4, NULL);
+		if (wlen == 0 || wlen >= LONG_PATH_MAX - 8) {
+			errno = ENAMETOOLONG;
+			return NULL;
+		}
+		wlen += 4;
+		if (wide_pattern_buf[wlen - 1] != L'\\' && wide_pattern_buf[wlen - 1] != L'/')
+			wide_pattern_buf[wlen++] = L'\\';
+		wide_pattern_buf[wlen++] = L'*';
+		wide_pattern_buf[wlen] = 0;
+
+		h = FindFirstFileW(wide_pattern_buf, &fdataw);
+		use_wide = 1;
+		goto check_handle;
 	}
+
 	/* copy name to temp buffer */
 	strcpy(pattern, name);
 
@@ -54,6 +100,8 @@ DIR *opendir(const char *name)
 
 	/* open find handle */
 	h = FindFirstFileA(pattern, &fdata);
+
+ check_handle:
 	if (h == INVALID_HANDLE_VALUE) {
 		DWORD err = GetLastError();
 		errno = (err == ERROR_DIRECTORY) ? ENOTDIR : err_win_to_posix();
@@ -63,10 +111,14 @@ DIR *opendir(const char *name)
 	/* initialize DIR structure and copy first dir entry */
 	dir = xzalloc(sizeof(DIR));
 	dir->dd_handle = h;
+	dir->use_wide = use_wide;
 	/* dir->not_first = 0; */
 	/* dir->got_dot = 0; */
 	/* dir->got_dotdot = 0; */
-	finddata2dirent(&dir->dd_dir, &fdata);
+	if (use_wide)
+		finddata2dirent_w(&dir->dd_dir, &fdataw);
+	else
+		finddata2dirent(&dir->dd_dir, &fdata);
 	return dir;
 }
 
@@ -80,22 +132,37 @@ struct dirent *readdir(DIR *dir)
 	/* if first entry, dirent has already been set up by opendir */
 	if (dir->not_first) {
 		/* get next entry and convert from WIN32_FIND_DATA to dirent */
-		WIN32_FIND_DATAA fdata;
-		if (FindNextFileA(dir->dd_handle, &fdata)) {
-			finddata2dirent(&dir->dd_dir, &fdata);
-		} else if (!dir->got_dot) {
-			strcpy(dir->dd_dir.d_name, ".");
-			dir->dd_dir.d_type = DT_DIR;
-		} else if (!dir->got_dotdot) {
-			strcpy(dir->dd_dir.d_name, "..");
-			dir->dd_dir.d_type = DT_DIR;
+		int found = 0;
+
+		if (dir->use_wide) {
+			WIN32_FIND_DATAW fdataw;
+			if (FindNextFileW(dir->dd_handle, &fdataw)) {
+				finddata2dirent_w(&dir->dd_dir, &fdataw);
+				found = 1;
+			}
 		} else {
-			DWORD lasterr = GetLastError();
-			/* POSIX says you shouldn't set errno when readdir can't
-			   find any more files; so, if another error we leave it set. */
-			if (lasterr != ERROR_NO_MORE_FILES)
-				errno = err_win_to_posix();
-			return NULL;
+			WIN32_FIND_DATAA fdata;
+			if (FindNextFileA(dir->dd_handle, &fdata)) {
+				finddata2dirent(&dir->dd_dir, &fdata);
+				found = 1;
+			}
+		}
+
+		if (!found) {
+			if (!dir->got_dot) {
+				strcpy(dir->dd_dir.d_name, ".");
+				dir->dd_dir.d_type = DT_DIR;
+			} else if (!dir->got_dotdot) {
+				strcpy(dir->dd_dir.d_name, "..");
+				dir->dd_dir.d_type = DT_DIR;
+			} else {
+				DWORD lasterr = GetLastError();
+				/* POSIX says you shouldn't set errno when readdir can't
+				   find any more files; so, if another error we leave it set. */
+				if (lasterr != ERROR_NO_MORE_FILES)
+					errno = err_win_to_posix();
+				return NULL;
+			}
 		}
 	}
 


### PR DESCRIPTION
Use wide API with `\\?\` prefix for paths approaching MAX_PATH. Adds get_long_path_w() helper with pre-allocated static buffers.

Fixes issues #562 and #143

Test results (Windows Server 2022):
```
  before: 968 passed, 131 failed
  after:  971 passed, 128 failed
```

Changed tests (all others identical):
```
  test                    before  after
  ls-long-path-works      FAIL    PASS
  rm-removes-long-path    FAIL    PASS
  stat-long-path-works    FAIL    PASS
```

```
function                                             old     new   delta
opendir                                              256     528    +272
get_long_path_w                                        -     176    +176
finddata2dirent_w                                      -      80     +80
mingw_unlink                                          96     160     +64
get_dtype                                              -      64     +64
readdir                                              240     288     +48
mingw_rmdir                                           80     128     +48
get_file_attr                                        320     352     +32
wpath.24                                               -      16     +16
wlong.23                                               -      16     +16
wide_pattern_buf                                       -      16     +16
wide_path_buf                                          -      16     +16
__imp_RemoveDirectoryW                                 -       8      +8
__imp_GetFullPathNameW                                 -       8      +8
__imp_GetFileAttributesExW                             -       8      +8
__imp_FindNextFileW                                    -       8      +8
__imp_FindFirstFileW                                   -       8      +8
__imp_DeleteFileW                                      -       8      +8
finddata2dirent                                       96       -     -96
------------------------------------------------------------------------------
(add/remove: 13/1 grow/shrink: 5/0 up/down: 896/-96)          Total: 800 bytes
```

---

## Alternative Approach

An alternative implementation using Wide APIs with `longPathAware` manifest (instead of `\\?\` prefix) is available at:

**https://github.com/doctorpangloss/busybox-w32/tree/fix-long-paths-wide-api**

**Comparison**

(tedious table formatting solved by LLM)

| Aspect | This PR (`\\?\` prefix) | Alternative (manifest) |
|--------|-------------------------|------------------------|
| Code delta | +800 bytes | +42 bytes (smaller) |
| Works on Win7/8/XP | Yes | No |
| Requires manifest | No | Yes (`longPathAware`) |
| Requires registry | No | Yes (`LongPathsEnabled`) |
| Path prefix handling | * | None needed |

*There might still be places where \\?\ is leaked out to the end user in error messages, I tested this in a bunch of scenarios and didn't see any, but still possible.

### Tradeoff

- **This PR** works on all Windows versions without external dependencies, but is more complex
- **Alternative** is simpler and follows Microsoft's modern guidance, but requires Windows 10 1607+ with `LongPathsEnabled` registry key

Both implementations pass the same test suite (branch `testsuite-long-paths`).
