### PR TITLE
Fix the flags for stat (again)

### DIFF
--- a/coreutils/ls.c
+++ b/coreutils/ls.c
@@ -1374,6 +1374,7 @@ int ls_main(int argc UNUSED_PARAM, char **argv)
 
 #if ENABLE_PLATFORM_MINGW32
 	/* Make calls to stat(2)/lstat(2) as efficient as possible */
+	/* this isn't a NOFORK applet so we don't need to restore afterwards */
 	flag = 0;
 	if (opt & OPT_l) {
 # if ENABLE_FEATURE_EXTRA_FILE_DATA

--- a/coreutils/stat.c
+++ b/coreutils/stat.c
@@ -790,6 +790,7 @@ int stat_main(int argc UNUSED_PARAM, char **argv)
 #endif
 #if ENABLE_FEATURE_EXTRA_FILE_DATA
 	/* Enable accurate link counts for directories */
+	/* this isn't a NOFORK applet so we don't need to restore afterwards */
 	flag = BB_STAT_COUNT_SUBDIRS;
 	stat(&flag, NULL);
 #endif

--- a/coreutils/test.c
+++ b/coreutils/test.c
@@ -885,12 +885,9 @@ int FAST_FUNC test_main2(struct cached_groupinfo *pgroupinfo, int argc, char **a
 #if BASH_TEST2
 	bool bt2 = 0;
 #endif
-
 #if ENABLE_PLATFORM_MINGW32
-	/* since this is a NOFORK applet the flags may still be matching a previous call */
-	/* old flags may include BB_STAT_NO_HAS_EXEC_FORMAT and make stat above give a wrong result */
 	char flags = 0;
-	char oldflags = stat(&flags, NULL);
+	char oldflags;
 #endif
 
 	arg0 = bb_basename(argv[0]);
@@ -915,6 +912,10 @@ int FAST_FUNC test_main2(struct cached_groupinfo *pgroupinfo, int argc, char **a
 		argv[argc] = NULL;
 	}
 	/* argc is unused after this point */
+
+	/* Since this is a NOFORK applet our caller may have altered the stat()
+	 * flags.  Temporarily reset them to the default. */
+	oldflags = stat(&flags, NULL);
 
 	/* We must do DEINIT_S() prior to returning */
 	INIT_S();

--- a/coreutils/test.c
+++ b/coreutils/test.c
@@ -886,6 +886,13 @@ int FAST_FUNC test_main2(struct cached_groupinfo *pgroupinfo, int argc, char **a
 	bool bt2 = 0;
 #endif
 
+#if ENABLE_PLATFORM_MINGW32
+	/* since this is a NOFORK applet the flags may still be matching a previous call */
+	/* old flags may include BB_STAT_NO_HAS_EXEC_FORMAT and make stat above give a wrong result */
+	char flags = 0;
+	char oldflags = stat(&flags, NULL);
+#endif
+
 	arg0 = bb_basename(argv[0]);
 	if ((ENABLE_TEST1 || ENABLE_TEST2 || ENABLE_ASH_TEST || ENABLE_HUSH_TEST)
 	 && (arg0[0] == '[')
@@ -1012,6 +1019,10 @@ int FAST_FUNC test_main2(struct cached_groupinfo *pgroupinfo, int argc, char **a
 	}
  ret:
 	DEINIT_S();
+#if ENABLE_PLATFORM_MINGW32
+	/* restore to the same flags as before */
+	stat(&oldflags, NULL);
+#endif
 	return res;
 }
 

--- a/findutils/find.c
+++ b/findutils/find.c
@@ -670,7 +670,6 @@ ACTF(type)
 #if ENABLE_FEATURE_FIND_EXECUTABLE
 ACTF(executable)
 {
-	/* If we are on mingw, mingw_access does proper handling inside it and restores the flags */
 	return access(fileName, X_OK) == 0;
 }
 #endif
@@ -1745,10 +1744,8 @@ int find_main(int argc UNUSED_PARAM, char **argv)
 #endif
 
 #if ENABLE_PLATFORM_MINGW32
-	/* Do this all the time. That way we prevent doing double-stats for
-	executable files (the executable check above uses access() which calls stat again)
-	And we don't need to worry about resetting at the end since this isn't a NOFORK applet.
-	*/
+	/* Avoid expensive checks for executable mode when stat() is called.
+	 * The -executable test uses access() which isn't affected by this. */
 	stat_flag = BB_STAT_NO_HAS_EXEC_FORMAT;
 	stat(&stat_flag, NULL);
 #endif

--- a/findutils/find.c
+++ b/findutils/find.c
@@ -1759,6 +1759,7 @@ int find_main(int argc UNUSED_PARAM, char **argv)
 #if ENABLE_PLATFORM_MINGW32
 	/* Do this all the time. That way we prevent doing double-stats for
 	executable files (the executable check above uses access() which calls stat again)
+	And we don't need to worry about resetting at the end since this isn't a NOFORK applet.
 	*/
 	stat_flag = BB_STAT_NO_HAS_EXEC_FORMAT;
 	stat(&stat_flag, NULL);
@@ -1774,13 +1775,6 @@ int find_main(int argc UNUSED_PARAM, char **argv)
 			G.exitstatus |= EXIT_FAILURE;
 		}
 	}
-
-#if ENABLE_PLATFORM_MINGW32
-	/* Reinstate costly check for executables.  flush_exec_plus() may
-	 * invoke a NOFORK applet */
-	stat_flag = 0;
-	stat(&stat_flag, NULL);
-#endif
 
 	IF_FEATURE_FIND_EXEC_PLUS(G.exitstatus |= flush_exec_plus();)
 	return G.exitstatus;

--- a/findutils/find.c
+++ b/findutils/find.c
@@ -670,20 +670,8 @@ ACTF(type)
 #if ENABLE_FEATURE_FIND_EXECUTABLE
 ACTF(executable)
 {
-#if ENABLE_PLATFORM_MINGW32
-	/* We do actually need to test for executability here */
-	/* This can't be moved inside mingw_access(), since it can't restore the
-	flags to what they were before */
-	int res;
-	char stat_flag = 0;
-	stat(&stat_flag, NULL);
-	res = access(fileName, X_OK) == 0;
-	stat_flag = BB_STAT_NO_HAS_EXEC_FORMAT;
-	stat(&stat_flag, NULL);
-	return res;
-#else
+	/* If we are on mingw, mingw_access does proper handling inside it and restores the flags */
 	return access(fileName, X_OK) == 0;
-#endif
 }
 #endif
 #if ENABLE_FEATURE_FIND_PERM

--- a/libbb/lineedit.c
+++ b/libbb/lineedit.c
@@ -943,7 +943,8 @@ static NOINLINE unsigned complete_cmd_dir_file(const char *command, int type)
 	char *dirbuf = NULL;
 #if ENABLE_PLATFORM_MINGW32
 	char stat_flag = type == FIND_EXE_ONLY ? 0 : BB_STAT_NO_HAS_EXEC_FORMAT;
-	stat(&stat_flag, NULL);
+	char oldflag;
+	oldflag = stat(&stat_flag, NULL);
 #endif
 
 	npaths = 1;
@@ -1091,8 +1092,7 @@ static NOINLINE unsigned complete_cmd_dir_file(const char *command, int type)
 	free(dirbuf);
 
 #if ENABLE_PLATFORM_MINGW32
-	stat_flag = 0;
-	stat(&stat_flag, NULL);
+	stat(&oldflag, NULL);
 #endif
 	return baselen;
 }

--- a/win32/mingw.c
+++ b/win32/mingw.c
@@ -2113,6 +2113,8 @@ int FAST_FUNC mingw_access(const char *name, int mode)
 {
 	int ret;
 	struct stat s;
+	char oldflag;
+	char newflag = 0;
 
 	/* Windows can only handle test for existence, read or write */
 	if (mode == F_OK || (mode & ~X_OK)) {
@@ -2122,13 +2124,18 @@ int FAST_FUNC mingw_access(const char *name, int mode)
 		}
 	}
 
+	/* If we reach this point, mode has the X_OK flag */
+	oldflag = mingw_stat(&newflag, NULL);
+
 	if (!mingw_stat(name, &s)) {
 		if ((s.st_mode&S_IXUSR)) {
+			mingw_stat(&oldflag, NULL);
 			return 0;
 		}
 		errno = EACCES;
 	}
 
+	mingw_stat(&oldflag, NULL);
 	return -1;
 }
 

--- a/win32/mingw.c
+++ b/win32/mingw.c
@@ -2124,19 +2124,21 @@ int FAST_FUNC mingw_access(const char *name, int mode)
 		}
 	}
 
-	/* If we reach this point, mode has the X_OK flag */
+	/* If we reach this point, mode has the X_OK flag.  Reset stat()
+	 * to its default behaviour, in case our caller has altered it. */
 	oldflag = mingw_stat(&newflag, NULL);
 
+	ret = -1;
 	if (!mingw_stat(name, &s)) {
 		if ((s.st_mode&S_IXUSR)) {
-			mingw_stat(&oldflag, NULL);
-			return 0;
+			ret = 0;
+		} else {
+			errno = EACCES;
 		}
-		errno = EACCES;
 	}
 
 	mingw_stat(&oldflag, NULL);
-	return -1;
+	return ret;
 }
 
 int FAST_FUNC mingw_rmdir(const char *path)

--- a/win32/mingw.c
+++ b/win32/mingw.c
@@ -739,8 +739,9 @@ static int do_lstat(int follow, const char *file_name, struct mingw_stat *buf)
 
 	if (buf == NULL) {
 		/* NULL buf sets optimisation flags */
+		char oldflag = flag;
 		flag = *file_name;
-		return 0;
+		return oldflag;
 	}
 
 	while (!(err=get_file_attr(file_name, &fdata))) {


### PR DESCRIPTION
Follow up to changes noted on https://github.com/rmyorston/busybox-w32/pull/600

The resetting before the final item with `find` didn't work, since we could have already executed a NOFORK applet while the flag was set.

And so this reverse that change and instead adds the handling inside of `test`.

And while I was at it I did:
- The handling inside of lineedit now restores flags to whatever they were before, rather than 0
- The mingw_access function now always sets flags to 0 when needed and restores afterwards

An example test for `find` is:

```sh
find -exec test -x {} \; -exec echo exec {} \; -o -exec echo noexec {} \;
# if the test -x worked then we echo 'exec FILENAME'
# and otherwise echo 'noexec FILENAME'
```

Test case:
```sh
mkdir testing
cd testing
echo '#!/bin/sh' >shellscript
echo '#!/bin/sh' >shellscript.sh
echo '#!/bin/sh' >shellscript.abcd
echo 'datadata' >abcd
```

```sh
~/git/busybox/testing$ ../busybox.exe ls -al
total 16
drwxrwxr-x    2 username  username          0 Jun 20 22:04 .
drwxrwxr-x   42 username  username          0 Jun 20 22:05 ..
-rw-rw-r--    1 username  username          9 Jun 20 22:04 abcd
-rwxrwxr-x    1 username  username         10 Jun 20 22:04 shellscript
-rwxrwxr-x    1 username  username         10 Jun 20 22:04 shellscript.abcd
-rwxrwxr-x    1 username  username         10 Jun 20 22:04 shellscript.sh
```

Before:
```sh
~/git/busybox/testing$ ../busybox.exe find -exec test -x {} \; -exec echo exec {} \; -o -exec echo noexec {} \;
exec .
noexec ./abcd
noexec ./shellscript
noexec ./shellscript.abcd
exec ./shellscript.sh
```
(Note the executability only appears based on the filename)

After: (matching the behaviour before a717c68449c8df642f6f2381618366a24734d184)
```sh
~/git/busybox/testing$ ../busybox.exe find -exec test -x {} \; -exec echo exec {} \; -o -exec echo noexec {} \;
exec .
noexec ./abcd
exec ./shellscript
exec ./shellscript.abcd
exec ./shellscript.sh
```