### PR TITLE
join: re-add accidentally removed return

### DIFF
--- a/coreutils/join.c
+++ b/coreutils/join.c
@@ -88,6 +88,7 @@ static void field_split(char *s, char sep, LINE *curr)
 		sl[n] = ps;
 		n++;
 		curr->fieldcount = n;
+		return;
 	}
 	/* default split: skip the initial whitespace and then any run
 	   of non-whitespace characters is a field */

--- a/testsuite/join.tests
+++ b/testsuite/join.tests
@@ -48,4 +48,10 @@ testing "join -o works for combinatorial" \
 	"a 123\na 456\n" \
 	"a abc\na def\n"
 
+testing "join -t works" \
+	"join -t A input -" \
+	"item 1A123Aabc\nitem 2A456Adef\n" \
+	"item 1A123\nitem 2A456\n" \
+	"item 1Aabc\nitem 2Adef\n"
+
 exit $FAILCOUNT


### PR DESCRIPTION
It broke single-character splitting

Also added a test to cover it.