### PR TITLE
ash, xargs: multiprocess handling fixes

### DIFF
--- a/findutils/xargs.c
+++ b/findutils/xargs.c
@@ -256,13 +256,13 @@ check_exit_codes:
 		/* Fall back to polling */
 		for (;;) {
 			DWORD nr = i + MAXIMUM_WAIT_OBJECTS > G.running_procs ?
-				MAXIMUM_WAIT_OBJECTS : (DWORD)(G.running_procs - i);
+				(DWORD)(G.running_procs - i) : MAXIMUM_WAIT_OBJECTS;
 			DWORD ret = WaitForMultipleObjects(nr, G.procs + i, FALSE, 100);
 
 			if (ret != WAIT_TIMEOUT)
 				break;
 			i += MAXIMUM_WAIT_OBJECTS;
-			if (i > G.running_procs)
+			if (i >= G.running_procs)
 				i = 0;
 		}
 	}

--- a/shell/ash.c
+++ b/shell/ash.c
@@ -4928,7 +4928,31 @@ waitpid_child(int *status, DWORD blocking)
 
 	if (pid_nr) {
 		do {
-			idx = WaitForMultipleObjects(pid_nr, proclist, FALSE, blocking);
+			if (pid_nr < MAXIMUM_WAIT_OBJECTS)
+				idx = WaitForMultipleObjects(pid_nr, proclist, FALSE, blocking);
+			else {
+				/* compare similar code in findutils/xargs.c */
+				/* Fall back to polling */
+				i = 0;
+				for (;;) {
+					DWORD nr;
+					TRACE(("poll many: i %d, pidnr: %d, maxwait: %d, blocking: %d\n", i, pid_nr, MAXIMUM_WAIT_OBJECTS, blocking));
+					nr = i + MAXIMUM_WAIT_OBJECTS > pid_nr ? (DWORD)(pid_nr - i) : MAXIMUM_WAIT_OBJECTS;
+					idx = WaitForMultipleObjects(nr, proclist + i, FALSE, blocking ? 100 : 0);
+					TRACE(("poll result: %d\n", idx));
+					if (idx != WAIT_TIMEOUT) {
+						idx += i;
+						break;
+					}
+					i += MAXIMUM_WAIT_OBJECTS;
+					if (i >= pid_nr) {
+						/* we have done one full scan */
+						if (!blocking)
+							break;
+						i = 0;
+					}
+				}
+			}
 			if (idx < pid_nr) {
 				GetExitCodeProcess(proclist[idx], &win_status);
 				*status = exit_code_to_wait_status(win_status);


### PR DESCRIPTION
Having more than 64 background jobs under `ash` caused an infinite loop, since WaitForMultipleObjects then returned an error, which then resulted in it busy-waiting on that error and also not being able to be killed with ^C.

And so I have split in two commits:

- Fixing the original code under `xargs` for more than MAXIMUM_WAIT_OBJECTS threads so that it works. (flipped a condition, and fixed an off-by-one error)

- And then making a copy of that code over to `ash.c` to handle its MAXIMUM_WAIT_OBJECTS needs.

And so to test, typing this at the console shouldn't cause ash to freeze.

```ash
for i in $(seq 1 70); do echo $i; sleep 10 & done
```