### PR TITLE
Fix more stat calls

### DIFF
--- a/libbb/executable.c
+++ b/libbb/executable.c
@@ -18,8 +18,13 @@ int FAST_FUNC file_is_executable(const char *name)
 #if !ENABLE_PLATFORM_MINGW32
 	return (!access(name, X_OK) && !stat(name, &s) && S_ISREG(s.st_mode));
 #else
+	int ret;
+	char newflag = 0; /* reset to default */
+	char oldflag = mingw_stat(&newflag, NULL);
 	/* expand WIN32 implementation of access(2) */
-	return (!stat(name, &s) && S_ISREG(s.st_mode) && (s.st_mode & S_IXUSR));
+	ret = !stat(name, &s) && S_ISREG(s.st_mode) && (s.st_mode & S_IXUSR);
+	mingw_stat(&oldflag, NULL);
+	return ret;
 #endif
 }
 

--- a/win32/process.c
+++ b/win32/process.c
@@ -165,12 +165,19 @@ spawnveq(int mode, const char *path, char *const *argv, char *const *env)
 	intptr_t ret;
 	struct stat st;
 	size_t len = 0;
+	char newflag = 0;
+	/* we can be called from applets that have adjusted flags */
+	char oldflag = mingw_stat(&newflag, NULL);
 
 	/*
 	 * Require that the file exists, is a regular file and is executable.
 	 * It may still contain garbage but we let spawnve deal with that.
 	 */
-	if (stat(path, &st) == 0) {
+	newflag = stat(path, &st) == 0;
+	/* reset it back */
+	mingw_stat(&oldflag, NULL);
+
+	if (newflag) {
 		if (!S_ISREG(st.st_mode) || !(st.st_mode&S_IXUSR)) {
 			errno = EACCES;
 			return -1;


### PR DESCRIPTION
It looks like my changes for the `find` applet had more fallout.

Looking through the rest of the code under `win32` and `libbb` for `*stat` calls, this should be it.

And so the test cases that it fixes are:

```sh
echo -e '#!/bin/sh\necho "$@"' >echo_sh
find -exec ./echo_sh {} +

cp busybox.exe busybox_noext
find -exec ./busybox_noext echo {} +
```